### PR TITLE
Be more lenient when checking django request module.

### DIFF
--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -1,6 +1,7 @@
 import sys
 import traceback
 import os
+import re
 from datetime import datetime
 
 import psutil
@@ -104,7 +105,7 @@ def create_payload(exception, exc_traceback=None, config=None, request=None, con
     if exc_traceback is None:
         exc_traceback = sys.exc_info()[2]
 
-    if request is not None and request.__module__ == 'django.http.request':
+    if request is not None and re.match(r'^django\.', request.__module__):
         request_payload = django_request_payload
     else:
         # TODO: figure out Flask support


### PR DESCRIPTION
I wasn't getting request data (params etc) in a brand new Django 1.9.4
app. I reduced the issue to the `request.__module__` check; the value of
`request.__module__` in my app was "django.core.handlers.wsgi" instead
of "django.http.request". I'm assuming this is some sort of
configuration detail (development server vs. production, maybe?).

Anyway, this change fixes that issue, although I have no idea if there
are side effects, so take my suggestions with a grain of salt. :)
