### PR TITLE
Convert exception to error message using str()

### DIFF
--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -32,7 +32,7 @@ def error_payload(exception, exc_traceback, config):
     print tb
     payload = {
         'class': type(exception) is dict and exception['error_class'] or exception.__class__.__name__,
-        'message': type(exception) is dict and exception['error_message'] or str(exception)
+        'message': type(exception) is dict and exception['error_message'] or str(exception),
         'backtrace': [dict(number=f[1], file=_filename(f[0]), method=f[2]) for f in reversed(tb)],
         'source': {}
     }

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -32,7 +32,7 @@ def error_payload(exception, exc_traceback, config):
     print tb
     payload = {
         'class': type(exception) is dict and exception['error_class'] or exception.__class__.__name__,
-        'message': type(exception) is dict and exception['error_message'] or exception.message,
+        'message': type(exception) is dict and exception['error_message'] or str(exception)
         'backtrace': [dict(number=f[1], file=_filename(f[0]), method=f[2]) for f in reversed(tb)],
         'source': {}
     }


### PR DESCRIPTION
`.message` is not defined for all exception classes. For example, `OSError` and `IOError` store error information in `errno`, `filename`, and `strerror`. `str()` is the most general method of converting objects to text, and for well-written exception classes it produces desired results. Compare

```
>>> ex.message
''
```
with
```
>>> str(ex)
'[Errno 2] No such file or directory'
```