### PR TITLE
Block call to honeybadger server when development like environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [0.1.0] - 2017-11-03
+### Added
+- Block calls to honeybadger server when development like environment unless 
+  explicitly forced.
+
 ## [0.0.6] - 2017-03-27
 ### Fixed
 - Added support for Django 1.10 middleware changes.

--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -4,6 +4,8 @@ from six.moves import zip
 from six import iteritems
 
 class Configuration(object):
+    DEVELOPMENT_ENVIRONMENTS = ['development', 'dev', 'test']
+
     OPTIONS = (
         ('api_key', str),
         ('project_root', str),
@@ -11,7 +13,8 @@ class Configuration(object):
         ('hostname', str),
         ('endpoint', str),
         ('params_filters', list),
-        ('trace_threshold', int)
+        ('trace_threshold', int),
+        ('force_report_data', bool),
     )
 
     def __init__(self, *args, **kwargs):
@@ -22,6 +25,7 @@ class Configuration(object):
         self.endpoint = 'https://api.honeybadger.io'
         self.params_filters = ['password', 'password_confirmation', 'credit_card']
         self.trace_threshold = 2000
+        self.force_report_data = False
 
         self.set_12factor_config()
         self.set_config_from_dict(kwargs)
@@ -46,3 +50,12 @@ class Configuration(object):
         for (key, value) in iteritems(config):
             if key in list(zip(*self.OPTIONS))[0]:
                 setattr(self, key, value)
+
+    def is_dev(self):
+        """Returns wether you are in a dev environment or not
+
+        A dev environment is defined in the constant DEVELOPMENT_ENVIRONMENTS
+
+        :rtype: bool
+        """
+        return self.environment in self.DEVELOPMENT_ENVIRONMENTS

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -4,7 +4,8 @@ import sys
 import logging
 import copy
 
-from .connection import send_notice
+import honeybadger.connection as connection
+import honeybadger.fake_connection as fake_connection
 from .payload import create_payload
 from .config import Configuration
 
@@ -19,7 +20,10 @@ class Honeybadger(object):
 
     def _send_notice(self, exception, exc_traceback=None, context={}):
         payload = create_payload(exception, exc_traceback, request=self.thread_local.request, config=self.config, context=context)
-        send_notice(self.config, payload)
+        if self.config.is_dev() and not self.config.force_report_data:
+            fake_connection.send_notice(self.config, payload)
+        else:
+            connection.send_notice(self.config, payload)
 
     def begin_request(self, request):
         self.thread_local.request = request

--- a/honeybadger/fake_connection.py
+++ b/honeybadger/fake_connection.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def send_notice(config, payload):
+    logger.debug('Using a fake connection. Will not make a real call to Honeybadger API')
+    logger.debug('The config used is {} with paylod {}'.format(config, payload))

--- a/honeybadger/fake_connection.py
+++ b/honeybadger/fake_connection.py
@@ -3,5 +3,5 @@ import logging
 logger = logging.getLogger(__name__)
 
 def send_notice(config, payload):
-    logger.debug('Using a fake connection. Will not make a real call to Honeybadger API')
-    logger.debug('The config used is {} with paylod {}'.format(config, payload))
+    logger.info('Using a fake connection. Will not make a real call to Honeybadger API')
+    logger.info('The config used is {} with paylod {}'.format(config, payload))

--- a/honeybadger/tests/test_config.py
+++ b/honeybadger/tests/test_config.py
@@ -30,3 +30,22 @@ def test_config_var_types_are_accurate():
 def test_can_only_set_valid_options():
     c = Configuration(foo='bar')
     print(c.foo)
+
+def test_valid_dev_environments():
+    valid_dev_environments = ['development', 'dev', 'test']
+
+    assert len(Configuration.DEVELOPMENT_ENVIRONMENTS) == len(valid_dev_environments)
+    assert set(Configuration.DEVELOPMENT_ENVIRONMENTS) == set(valid_dev_environments)
+
+def test_is_dev_true_for_dev_environments():
+    for env in Configuration.DEVELOPMENT_ENVIRONMENTS:
+        c = Configuration(environment=env)
+        assert c.is_dev()
+
+def test_is_dev_false_for_non_dev_environments():
+    c = Configuration(environment='production')
+    assert c.is_dev() == False
+
+def test_force_report_data_not_active():
+    c = Configuration()
+    assert c.force_report_data == False

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -8,8 +8,6 @@ from honeybadger import Honeybadger
 from mock import MagicMock, patch
 
 
-
-
 def test_set_context():
     honeybadger = Honeybadger()
     honeybadger.set_context(foo='bar')

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -5,6 +5,10 @@ from nose.tools import raises
 
 from .utils import mock_urlopen
 from honeybadger import Honeybadger
+from mock import MagicMock, patch
+
+
+
 
 def test_set_context():
     honeybadger = Honeybadger()
@@ -13,6 +17,36 @@ def test_set_context():
     honeybadger.set_context(bar='foo')
     eq_(honeybadger.thread_local.context, dict(foo='bar', bar='foo'))
 
+
+def test_notify_fake_connection_dev_environment():
+    hb = Honeybadger()
+    hb.configure(api_key='aaa')
+    with patch('honeybadger.fake_connection.send_notice', side_effect=MagicMock(return_value=True)) as fake_connection:
+        with patch('honeybadger.connection.send_notice', side_effect=MagicMock(return_value=True)) as connection:
+            hb.notify(error_class='Exception', error_message='Test message.', context={'foo': 'bar'})
+
+            assert fake_connection.call_count == 1
+            assert connection.call_count == 0
+
+def test_notify_fake_connection_dev_environment_with_force():
+    hb = Honeybadger()
+    hb.configure(api_key='aaa', force_report_data=True)
+    with patch('honeybadger.fake_connection.send_notice', side_effect=MagicMock(return_value=True)) as fake_connection:
+        with patch('honeybadger.connection.send_notice', side_effect=MagicMock(return_value=True)) as connection:
+            hb.notify(error_class='Exception', error_message='Test message.', context={'foo': 'bar'})
+
+            assert fake_connection.call_count == 0
+            assert connection.call_count == 1
+
+def test_notify_fake_connection_non_dev_environment():
+    hb = Honeybadger()
+    hb.configure(api_key='aaa', environment='production')
+    with patch('honeybadger.fake_connection.send_notice', side_effect=MagicMock(return_value=True)) as fake_connection:
+        with patch('honeybadger.connection.send_notice', side_effect=MagicMock(return_value=True)) as connection:
+            hb.notify(error_class='Exception', error_message='Test message.', context={'foo': 'bar'})
+
+            assert fake_connection.call_count == 0
+            assert connection.call_count == 1
 
 def test_notify_with_custom_params():
     def test_payload(request):
@@ -24,7 +58,7 @@ def test_notify_with_custom_params():
     hb = Honeybadger()
 
     with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key='aaa')
+        hb.configure(api_key='aaa', force_report_data=True)
         hb.notify(error_class='Exception', error_message='Test message.', context={'foo': 'bar'})
 
 
@@ -38,7 +72,7 @@ def test_notify_with_exception():
     hb = Honeybadger()
 
     with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key='aaa')
+        hb.configure(api_key='aaa', force_report_data=True)
         hb.notify(ValueError('Test value error.'))
 
 def test_notify_context_merging():
@@ -49,6 +83,6 @@ def test_notify_context_merging():
     hb = Honeybadger()
 
     with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key='aaa')
+        hb.configure(api_key='aaa', force_report_data=True)
         hb.set_context(foo='bar')
         hb.notify(error_class='Exception', error_message='Test.', context=dict(bar='foo'))

--- a/honeybadger/tests/test_fake_connection.py
+++ b/honeybadger/tests/test_fake_connection.py
@@ -11,5 +11,5 @@ def test_send_notice_logging(l):
     send_notice(config, payload)
 
     l.check(
-        ('honeybadger.fake_connection', 'DEBUG', 'Using a fake connection. Will not make a real call to Honeybadger API'),
-        ('honeybadger.fake_connection', 'DEBUG', 'The config used is {} with paylod {}'.format(config, payload)))
+        ('honeybadger.fake_connection', 'INFO', 'Using a fake connection. Will not make a real call to Honeybadger API'),
+        ('honeybadger.fake_connection', 'INFO', 'The config used is {} with paylod {}'.format(config, payload)))

--- a/honeybadger/tests/test_fake_connection.py
+++ b/honeybadger/tests/test_fake_connection.py
@@ -1,0 +1,15 @@
+from honeybadger.fake_connection import send_notice
+
+from testfixtures import log_capture
+import json
+
+@log_capture()
+def test_send_notice_logging(l):
+    config = {'api_key': 'aaa'}
+    payload = json.dumps({'test': 'payload'})
+
+    send_notice(config, payload)
+
+    l.check(
+        ('honeybadger.fake_connection', 'DEBUG', 'Using a fake connection. Will not make a real call to Honeybadger API'),
+        ('honeybadger.fake_connection', 'DEBUG', 'The config used is {} with paylod {}'.format(config, payload)))

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'six'
     ],
     test_suite='nose.collector',
-    tests_require=['nose', 'mock']
+    tests_require=['nose', 'mock', 'testfixtures']
 )


### PR DESCRIPTION
## What does this PR do?

The python library by default tries to hit the honeybadger server it doesn't matter in which environment you are on. If you don't want to, is really annoying because you don't provide a valid key for the library to connect but it creates unnecessary noise. The aim of this PR is to enhance the functionality of the library so when you are in a development like environment it doesn't hit the honeybadger server by default and the applications don't have to worry about that unless really necessary.

## Where should the reviewer start?

The core and general functionality of the library was kept the same, but just expanding for what it was mentioned before.

## Any background context you want to provide?

This PR was inspired in using the same functionality that is present in the ruby library. The behaviour is really similar and the implementation is based as well on the ruby library:

- https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/config/defaults.rb#L24
- https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/backend/null.rb
- https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/config.rb#L147