### PR TITLE
Fix thread local issues

### DIFF
--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -36,7 +36,7 @@ def test_threading():
 def test_notify_fake_connection_dev_environment():
     hb = Honeybadger()
     hb.configure(api_key='aaa')
-    with patch('honeybadger.fake_connectiogn.send_notice', side_effect=MagicMock(return_value=True)) as fake_connection:
+    with patch('honeybadger.fake_connection.send_notice', side_effect=MagicMock(return_value=True)) as fake_connection:
         with patch('honeybadger.connection.send_notice', side_effect=MagicMock(return_value=True)) as connection:
             hb.notify(error_class='Exception', error_message='Test message.', context={'foo': 'bar'})
 


### PR DESCRIPTION
Added `_get_context` and `_get_request` methods to core Honeybadger object to return sane defaults from thread local data if the data hasn't been set yet (eg. after a thread has been forked)

Added an integration test to make sure `.notify` works properly within a new thread.

Fixes #20 