### PR TITLE
Don't fail when source file is missing

### DIFF
--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -44,7 +44,7 @@ def error_payload(exception, exc_traceback, config):
         'source': {}
     }
 
-    if len(tb) > 0:
+    if len(tb) > 0 and os.path.isfile(tb[-1][0]):
         with open(tb[-1][0], 'rt', encoding='utf-8') as f:
             contents = f.readlines()
 

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -59,6 +59,16 @@ def test_error_payload_source_line_midfile():
         eq_(traceback_mock.call_count, 1)
         eq_(payload['source'], expected)
 
+
+@patch('os.path.isfile', return_value=False)
+def test_error_payload_source_missing_file(_isfile):
+    with mock_traceback(line_no=5) as traceback_mock:
+        config = Configuration()
+        payload = error_payload(
+            dict(error_class='Exception', error_message='Test'), None, config)
+        eq_(payload['source'], {})
+
+
 def test_server_payload():
     config = Configuration(project_root=os.path.dirname(__file__), environment='test', hostname='test.local')
     payload = server_payload(config)


### PR DESCRIPTION
## Background

I have a project that uses [lxml](http://lxml.de). This package is written in Cython (C native code). Our code parses a given XML document using XSD schema and then performs schematron validation. 
Any issue during the process results in raising an exception.

## Problem
A stacktrace might include relative paths to source files. When a code, that had failed, comes from an external package that is built using a native code (for example with Cython), calling `open` will raise the "file not found" exception. As the result, sending a notification will fail on creating payload and the exception won't be reported (except the local logs if configured).

For example, this stackgrace, that comes from parsing an invalid XML document, includes references to relative paths:

```
Python 3.6.4 (default, Jan  6 2018, 11:51:59)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from lxml import etree as xml
>>> parser_document = xml.parse('xsd/schema.xsd')
>>> parser = xml.XMLParser(schema=xml.XMLSchema(parser_document))
>>> document = xml.parse('test/requests/test_xml_update_invalid_schema.xml', parser)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "src/lxml/etree.pyx", line 3444, in lxml.etree.parse (src/lxml/etree.c:83185)
  File "src/lxml/parser.pxi", line 1834, in lxml.etree._parseDocument (src/lxml/etree.c:120757)
  File "src/lxml/parser.pxi", line 1860, in lxml.etree._parseDocumentFromURL (src/lxml/etree.c:121104)
  File "src/lxml/parser.pxi", line 1764, in lxml.etree._parseDocFromFile (src/lxml/etree.c:120012)
  File "src/lxml/parser.pxi", line 1161, in lxml.etree._BaseParser._parseDocFromFile (src/lxml/etree.c:114561)
  File "src/lxml/parser.pxi", line 598, in lxml.etree._ParserContext._handleParseResultDoc (src/lxml/etree.c:107738)
  File "src/lxml/parser.pxi", line 709, in lxml.etree._handleParseResult (src/lxml/etree.c:109447)
  File "src/lxml/parser.pxi", line 638, in lxml.etree._raiseParseError (src/lxml/etree.c:108301)
  File "<string>", line 0
[...]
```

`src/lxml/parser.pxi` cannot be accessed using `open` function thus sending a Honeybadger notification fails.

## Proposed solution
While a source is a nice information to have, it is not more critical than a report itself. Leave `source` key empty when the file is not available for reading. 

---

Btw. The newest version is not available for python3:

```bash
~ λ pip install honeybadger
Collecting honeybadger
Requirement already satisfied: psutil in /usr/local/lib/python3.6/site-packages (from honeybadger)
Requirement already satisfied: six in /usr/local/lib/python3.6/site-packages (from honeybadger)
Installing collected packages: honeybadger
Successfully installed honeybadger-0.0.6
```