### PR TITLE
Run tests on all currently supported framework versions and their supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.7
 install:
   - pip install psutil six
-  - pip install Django==$DJANGO_VERSION Flask==$FLASK_VERSION
   - python setup.py develop
 env:
   - DJANGO_VERSION=1.11.25

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.7
 install:
   - pip install psutil six
+  - pip install Django==$DJANGO_VERSION Flask==$FLASK_VERSION
   - python setup.py develop
 env:
   - DJANGO_VERSION=1.11.25

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
       env: DJANGO_VERSION=2.1.13
     - python: 3.4
       env: DJANGO_VERSION=2.2.6
+    - python: 3.4
+      env: FLASK_VERSION=1.1.1
 script: python setup.py test
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: python
 python:
   - 2.7
-  - 3.2
+  - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 install:
   - pip install psutil six
   - python setup.py develop
+env:
+  - DJANGO_VERSION=1.11.25
+  - DJANGO_VERSION=2.1.13
+  - DJANGO_VERSION=2.2.6
+  - FLASK_VERSION=1.0.4
+  - FLASK_VERSION=1.1.1
 script: python setup.py test
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.7
 install:
   - pip install psutil six
+  - ./scripts/install_frameworks.sh
   - python setup.py develop
 env:
   - DJANGO_VERSION=1.11.25
@@ -14,6 +15,16 @@ env:
   - DJANGO_VERSION=2.2.6
   - FLASK_VERSION=1.0.4
   - FLASK_VERSION=1.1.1
+matrix:
+  exclude:
+    - python: 2.7
+      env: DJANGO_VERSION=2.1.13
+    - python: 2.7
+      env: DJANGO_VERSION=2.2.6
+    - python: 3.4
+      env: DJANGO_VERSION=2.1.13
+    - python: 3.4
+      env: DJANGO_VERSION=2.2.6
 script: python setup.py test
 notifications:
   slack:

--- a/honeybadger/contrib/flask.py
+++ b/honeybadger/contrib/flask.py
@@ -64,8 +64,8 @@ class FlaskPlugin(Plugin):
         }
 
         # Add query params
-        params = filter_dict(dict(_request.args), config.params_filters)
-        params.update(filter_dict(dict(_request.form), config.params_filters))
+        params = filter_dict(_request.args.to_dict(flat=False), config.params_filters)
+        params.update(filter_dict(_request.form.to_dict(flat=False), config.params_filters))
 
         payload['params'] = params
 

--- a/honeybadger/tests/contrib/test_flask.py
+++ b/honeybadger/tests/contrib/test_flask.py
@@ -7,15 +7,20 @@ from honeybadger import honeybadger
 from honeybadger.config import Configuration
 from honeybadger.contrib.flask import FlaskPlugin, FlaskHoneybadger
 
-PY3_2 = sys.version_info[0:2] == (3, 2)
-
+PYTHON_VERSION = sys.version_info[0:2]
 
 class FlaskPluginTestCase(unittest.TestCase):
     def setUp(self):
-        if PY3_2:
-            self.skipTest(
-                'Flask requires Python3 > 3.2. More info at http://flask.pocoo.org/docs/0.12/python3/#requirements')
         import flask
+
+        if flask.__version__.startswith('0.12') and PYTHON_VERSION != (2, 6) and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 3):
+            self.skipTest('Flask 0.12 requires Python 2.6, 2.7 or Python3 > 3.2')
+        
+        if flask.__version__.startswith('1.0') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 4):
+            self.skipTest('Flask 1.0 requires Python 2.7 or Python3 > 3.3')
+
+        if flask.__version__.startswith('1.1') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 5):
+            self.skipTest('Flask 1.1 requires Python 2.7 or Python3 > 3.4')
 
         self.config = Configuration()
 
@@ -51,12 +56,11 @@ class FlaskPluginTestCase(unittest.TestCase):
             self.assertEqual(payload['action'], 'foo')
             self.assertDictEqual(payload['params'], {'a': ['1', '2'], 'foo': ['bar']})
             self.assertDictEqual(payload['session'], {})
-            self.assertDictEqual(payload['cgi_data'], {
-                'Content-Length': '0',
+            self.assertDictContainsSubset({
                 'Host': 'server:1234',
                 'X-Wizard-Color': 'grey',
                 'REQUEST_METHOD': 'GET'
-            })
+            }, payload['cgi_data'])
             self.assertDictEqual(payload['context'], {'k': 'value'})
 
     def test_get_request_with_session(self):
@@ -71,11 +75,10 @@ class FlaskPluginTestCase(unittest.TestCase):
             self.assertEqual(payload['action'], 'foo')
             self.assertDictEqual(payload['params'], {})
             self.assertDictEqual(payload['session'], {'answer': 42, 'password': '[FILTERED]'})
-            self.assertDictEqual(payload['cgi_data'], {
-                'Content-Length': '0',
+            self.assertDictContainsSubset({
                 'Host': 'server:1234',
                 'REQUEST_METHOD': 'GET'
-            })
+            }, payload['cgi_data'])
             self.assertDictEqual(payload['context'], {'k': 'value'})
 
     def test_post_request(self):
@@ -120,11 +123,17 @@ class FlaskPluginTestCase(unittest.TestCase):
 class FlaskHoneybadgerTestCase(unittest.TestCase):
 
     def setUp(self):
-        if PY3_2:
-            self.skipTest(
-                'Flask requires Python3 > 3.2. More info at http://flask.pocoo.org/docs/0.12/python3/#requirements')
-
         import flask
+
+        if flask.__version__.startswith('0.12') and PYTHON_VERSION != (2, 6) and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 3):
+            self.skipTest('Flask 0.12 requires Python 2.6, 2.7 or Python3 > 3.2')
+        
+        if flask.__version__.startswith('1.0') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 4):
+            self.skipTest('Flask 1.0 requires Python 2.7 or Python3 >= 3.4')
+
+        if flask.__version__.startswith('1.1') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 5):
+            self.skipTest('Flask 1.1 requires Python 2.7 or Python3 >= 3.5')
+
         import werkzeug
 
         self.default_headers = {

--- a/scripts/install_frameworks.sh
+++ b/scripts/install_frameworks.sh
@@ -2,3 +2,4 @@
 set -ev
 [ ! -z "$DJANGO_VERSION" ] && pip install Django==$DJANGO_VERSION
 [ ! -z "$FLASK_VERSION" ] && pip install Flask==$FLASK_VERSION
+echo "OK"

--- a/scripts/install_frameworks.sh
+++ b/scripts/install_frameworks.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ev
+[ ! -z "$DJANGO_VERSION" ] && pip install Django==$DJANGO_VERSION
+[ ! -z "$FLASK_VERSION" ] && pip install Flask==$FLASK_VERSION

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ from setuptools import setup
 
 tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'Flask>=1.0']
 
-if sys.version_info[0:2] == (3, 4):
+if sys.version_info[0:2] <= (3, 4):
     tests_require.append('Django>=1.11,<1.12')
 else:
-    tests_require.append('Django>=1.11,<3.0')
+    tests_require.append('Django>=2.1,<3.0')
 
-    
+
 def get_version():
     with open('honeybadger/version.py', encoding='utf-8') as f:
         return re.search(r'^__version__ = [\'"]([^\'"]+)[\'"]', f.read(), re.M).group(1)

--- a/setup.py
+++ b/setup.py
@@ -4,17 +4,27 @@ import os
 from codecs import open
 from setuptools import setup
 
-DJANGO_VERSION = os.environ.get('DJANGO_VERSION', '1.11')
-FLASK_VERSION  = os.environ.get('FLASK_VERSION', '1.0')
+tests_require = ['nose', 'mock', 'testfixtures', 'blinker']
 
-tests_require = ['nose', 'mock', 'testfixtures', 'Flask>={}'.format(FLASK_VERSION), 'blinker']
+DJANGO_VERSION = os.environ.get('DJANGO_VERSION', None)
+FLASK_VERSION  = os.environ.get('FLASK_VERSION', None)
 
 # For some reason, Django 2.2.5 gets installed for Python 3.4, but breaks.
 # Python 3.4 is not officially supported by the 2.2 series, so not sure what's going on here.
+# Work-around is to force Django 1.11 to be installed for Python 3.4
 if sys.version_info[0:2] == (3, 4):
+    DJANGO_VERSION = '1.11'
+
+if DJANGO_VERSION:
     tests_require.append('django=={}'.format(DJANGO_VERSION))
 else:
-    tests_require.append('django>={}'.format(DJANGO_VERSION))
+    tests_require.append('django>=1.11')
+
+if FLASK_VERSION:
+    tests_require.append('Flask=={}'.format(FLASK_VERSION))
+else:
+    tests_require.append('Flask>=1.0')
+
     
 def get_version():
     with open('honeybadger/version.py', encoding='utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -4,26 +4,12 @@ import os
 from codecs import open
 from setuptools import setup
 
-tests_require = ['nose', 'mock', 'testfixtures', 'blinker']
+tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'Flask>=1.0']
 
-DJANGO_VERSION = os.environ.get('DJANGO_VERSION', None)
-FLASK_VERSION  = os.environ.get('FLASK_VERSION', None)
-
-# For some reason, Django 2.2.5 gets installed for Python 3.4, but breaks.
-# Python 3.4 is not officially supported by the 2.2 series, so not sure what's going on here.
-# Work-around is to force Django 1.11 to be installed for Python 3.4
 if sys.version_info[0:2] == (3, 4):
-    DJANGO_VERSION = '1.11'
-
-if DJANGO_VERSION:
-    tests_require.append('django=={}'.format(DJANGO_VERSION))
+    tests_require.append('Django>=1.11,<1.12')
 else:
-    tests_require.append('django>=1.11')
-
-if FLASK_VERSION:
-    tests_require.append('Flask=={}'.format(FLASK_VERSION))
-else:
-    tests_require.append('Flask>=1.0')
+    tests_require.append('Django>=1.11,<3.0')
 
     
 def get_version():

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,20 @@
 import re
 import sys
-
+import os
 from codecs import open
 from setuptools import setup
 
+DJANGO_VERSION = os.environ.get('DJANGO_VERSION', '1.11')
+FLASK_VERSION  = os.environ.get('FLASK_VERSION', '1.0')
 
-tests_require = ['nose', 'mock', 'testfixtures', 'Flask>=1.0', 'blinker']
+tests_require = ['nose', 'mock', 'testfixtures', 'Flask>={}'.format(FLASK_VERSION), 'blinker']
 
 # For some reason, Django 2.2.5 gets installed for Python 3.4, but breaks.
 # Python 3.4 is not officially supported by the 2.2 series, so not sure what's going on here.
 if sys.version_info[0:2] == (3, 4):
-    tests_require.append('django==1.11')
+    tests_require.append('django=={}'.format(DJANGO_VERSION))
 else:
-    tests_require.append('django>=1.11')
+    tests_require.append('django>={}'.format(DJANGO_VERSION))
     
 def get_version():
     with open('honeybadger/version.py', encoding='utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,16 @@ import sys
 from codecs import open
 from setuptools import setup
 
-# Django 2 requires at least python 3.4
-PY3_4 = sys.version_info >= (3, 4)
-PY3_2 = sys.version_info[0:2] == (3, 2)
 
-tests_require = ['nose', 'mock', 'testfixtures', 'Flask>=0.8', 'blinker']
+tests_require = ['nose', 'mock', 'testfixtures', 'Flask>=1.0', 'blinker']
 
-if PY3_4:
-    tests_require.append('django')
-elif PY3_2:
-    tests_require.append('django==1.8')
+# For some reason, Django 2.2.5 gets installed for Python 3.4, but breaks.
+# Python 3.4 is not officially supported by the 2.2 series, so not sure what's going on here.
+if sys.version_info[0:2] == (3, 4):
+    tests_require.append('django==1.11')
 else:
-    tests_require.append('django<2')
-
-# Ugly fix for testfixtures on Python 3.2
-if PY3_2:
-    tests_require.remove('testfixtures')
-    tests_require.append('testfixtures==5.3.1')
-
-
+    tests_require.append('django>=1.11')
+    
 def get_version():
     with open('honeybadger/version.py', encoding='utf-8') as f:
         return re.search(r'^__version__ = [\'"]([^\'"]+)[\'"]', f.read(), re.M).group(1)
@@ -42,6 +33,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Monitoring'
     ],
     install_requires=[


### PR DESCRIPTION
This PR adds tests for all the currently supported framework versions (Django 1.11.x LTS, 2.1.x and 2.2.x, Flask 1.0 and 1.1) and their supported Python versions (2.7, 3.4, 3.5, 3.6, 3.7)

We've dropped support for any framework or Python versions not listed here.