### PR TITLE
Filter sensitive HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The following options are available to you:
 | hostname | `str` | The hostname of the current server. | `"badger01"` | `HONEYBADGER_HOSTNAME` |
 | endpoint | `str` | `"https://api.honeybadger.io"` | `"https://honeybadger.example.com/"` | `HONEYBADGER_ENDPOINT` |
 | params_filters | `list` | `['password', 'password_confirmation', 'credit_card']` | `['super', 'secret', 'keys']` | `HONEYBADGER_PARAMS_FILTERS` |
+| http_headers_filters | `list` | `['HTTP_COOKIE', 'CSRF_COOKIE']` | `['super', 'secret', 'headers']` | `HONEYBADGER_HTTP_HEADERS_FILTERS` |
 | force_report_data | `bool` | `False` | `True` | `HONEYBADGER_FORCE_REPORT_DATA` |
 
 ## Public Methods

--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -13,6 +13,7 @@ class Configuration(object):
         ('hostname', str),
         ('endpoint', str),
         ('params_filters', list),
+        ('http_headers_filters', list),
         ('force_report_data', bool),
     )
 
@@ -23,6 +24,7 @@ class Configuration(object):
         self.hostname = socket.gethostname()
         self.endpoint = 'https://api.honeybadger.io'
         self.params_filters = ['password', 'password_confirmation', 'credit_card']
+        self.http_headers_filters = ['HTTP_COOKIE', 'CSRF_COOKIE']
         self.force_report_data = False
 
         self.set_12factor_config()
@@ -42,7 +44,6 @@ class Configuration(object):
                     val = bool(val)
             except:
                 pass
-
 
             setattr(self, option, val)
 

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -112,6 +112,10 @@ class DjangoHoneybadgerMiddleware(MiddlewareMixin):
         return None
 
     def process_exception(self, request, exception):
+        for key in honeybadger.config.http_headers_filters:
+            if key in request.environ.keys():
+                request.environ[key] = '[FILTERED]'
+
         honeybadger.notify(exception)
         clear_request()
         return None


### PR DESCRIPTION
`DjangoHoneybadgerMiddleware` leaks sensitive HTTP headers

Currently, there is no way to prevent the leakage of sensitive HTTP headers such as: 

  - `HTTP_COOKIE`
  - `CSRF_COOKIE`

This PR addresses this change by introducing `Configuration.http_headers_filters`.
