### PR TITLE
Fix context for threads

### DIFF
--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -55,6 +55,7 @@ class Honeybadger(object):
         self.config.set_config_from_dict(kwargs)
 
     def set_context(self, **kwargs):
+        # This operation is an update, not a set!
         self.thread_local.context = self._get_context()
         self.thread_local.context.update(kwargs)
 
@@ -64,7 +65,7 @@ class Honeybadger(object):
     @contextmanager
     def context(self, **kwargs):
         original_context = copy.copy(self._get_context())
-        self.thread_local.context.update(kwargs)
+        self.set_context(**kwargs)
         try:
             yield
         except:


### PR DESCRIPTION

Bug fix for `with honeybadger.context` when using threads (Flask, gevent)

The change resolves issues where the context attribute is not initialized in the current thread which results in:
```
 File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/Users/me/Envs/workforce_optimizer-rqDNrIoM/lib/python3.7/site-packages/honeybadger/core.py", line 67, in context
    self.thread_local.context.update(kwargs)
  File "src/gevent/local.py", line 408, in gevent._local.local.__getattribute__
AttributeError: 'gevent._local.local' object has no attribute 'context'
```

