### PR TITLE
Retire Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7
@@ -17,10 +16,6 @@ env:
   - FLASK_VERSION=1.1.1
 matrix:
   exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=2.2.11
-    - python: 2.7
-      env: DJANGO_VERSION=3.0.4
     - python: 3.4
       env: DJANGO_VERSION=2.2.11
     - python: 3.4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": ".venv/bin/python3"
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ When any uncaught exceptions occur, Honeybadger will send the data off to the Ho
 
 ## Supported Versions
 
-Tested with Django 1.9 and 1.10 and Python 2.7 through 3.5. Django integration is done via middleware and will work out of the box up to version 1.10.
+Tested with Python 3.5 - 3.8 against Django latest and LTS releases (1.11.29, 2.2.11, 3.0.4) as well as Flask 1.0 and 1.0.
 
 ## Getting Started
 
@@ -23,15 +23,13 @@ the `force_report_data` setting.
 
 ### Django
 
-*NOTE: Middleware configuration has changed in Django 1.10. Instead of using `MIDDLEWARE_CLASSES`, simply use the `MIDDLEWARE` configuration instead.*
-
-In a Django application, add the Honeybadger Django middleware to *the top* of your `MIDDLEWARE_CLASSES` config variable:
+In a Django application, add the Honeybadger Django middleware to *the top* of your `MIDDLEWARE` config variable:
 
 ```python
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
   'honeybadger.middleware.DjangoHoneybadgerMiddleware',
   ...
-)
+]
 ```
 
 It's important that the Honeybadger middleware is at the top, so that it wraps the entire request process, including all other middlewares.

--- a/honeybadger/tests/contrib/test_django.py
+++ b/honeybadger/tests/contrib/test_django.py
@@ -33,7 +33,7 @@ def versions_match():
     import django
 
     VERSION_MATRIX = {
-        '1.11': sys.version_info >= (2, 7),
+        '1.11': sys.version_info >= (3, 5),
         '2.2':  sys.version_info >= (3, 5),
         '3.0':  sys.version_info >= (3, 6),
         '3.1':  sys.version_info >= (3, 6)

--- a/honeybadger/tests/contrib/test_flask.py
+++ b/honeybadger/tests/contrib/test_flask.py
@@ -13,14 +13,14 @@ class FlaskPluginTestCase(unittest.TestCase):
     def setUp(self):
         import flask
 
-        if flask.__version__.startswith('0.12') and PYTHON_VERSION != (2, 6) and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 3):
-            self.skipTest('Flask 0.12 requires Python 2.6, 2.7 or Python3 > 3.2')
+        if flask.__version__.startswith('0.12') and PYTHON_VERSION < (3, 3):
+            self.skipTest('Flask 0.12 requires Python > 3.2')
         
-        if flask.__version__.startswith('1.0') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 4):
-            self.skipTest('Flask 1.0 requires Python 2.7 or Python3 > 3.3')
+        if flask.__version__.startswith('1.0') and PYTHON_VERSION < (3, 4):
+            self.skipTest('Flask 1.0 requires Python > 3.3')
 
-        if flask.__version__.startswith('1.1') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 5):
-            self.skipTest('Flask 1.1 requires Python 2.7 or Python3 > 3.4')
+        if flask.__version__.startswith('1.1') and PYTHON_VERSION < (3, 5):
+            self.skipTest('Flask 1.1 requires Python > 3.4')
 
         self.config = Configuration()
 
@@ -125,14 +125,14 @@ class FlaskHoneybadgerTestCase(unittest.TestCase):
     def setUp(self):
         import flask
 
-        if flask.__version__.startswith('0.12') and PYTHON_VERSION != (2, 6) and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 3):
-            self.skipTest('Flask 0.12 requires Python 2.6, 2.7 or Python3 > 3.2')
+        if flask.__version__.startswith('0.12') and PYTHON_VERSION < (3, 3):
+            self.skipTest('Flask 0.12 requires Python > 3.2')
         
-        if flask.__version__.startswith('1.0') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 4):
-            self.skipTest('Flask 1.0 requires Python 2.7 or Python3 >= 3.4')
+        if flask.__version__.startswith('1.0') and PYTHON_VERSION < (3, 4):
+            self.skipTest('Flask 1.0 requires Python >= 3.4')
 
-        if flask.__version__.startswith('1.1') and PYTHON_VERSION != (2, 7) and PYTHON_VERSION < (3, 5):
-            self.skipTest('Flask 1.1 requires Python 2.7 or Python3 >= 3.5')
+        if flask.__version__.startswith('1.1') and PYTHON_VERSION < (3, 5):
+            self.skipTest('Flask 1.1 requires Python >= 3.5')
 
         import werkzeug
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# This script is for local test debugging with Docker.
+# docker run -v $PWD:/app --env DJANGO_VERSION=x python:<VERSION> /app/run_tests.sh
+cd /app
+python --version
+pip --version
+pip install psutil six
+[ ! -z "$DJANGO_VERSION" ] && pip install Django==$DJANGO_VERSION
+[ ! -z "$FLASK_VERSION" ] && pip install Flask==$FLASK_VERSION
+python setup.py develop
+python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,12 @@ from setuptools import setup
 
 tests_require = ['nose', 'mock', 'testfixtures', 'blinker']
 
-if sys.version_info[0:2] == (2, 7) or sys.version_info[0:2] >= (3, 5):
+if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')
     # For some reason, Flask 1.1.1 is pulling in Jinja2 3.0.0 which causes syntax errors.
     tests_require.append('Jinja2<3.0.0')
 
-if sys.version_info[0:2] == (2, 7):
-    tests_require.append('Django==1.11')
-elif sys.version_info[0:2] <= (3, 5):
+if sys.version_info[0:2] <= (3, 5):
     tests_require.append('Django>=1.11,<=2.2')
 else:
     tests_require.append('Django>3.0,<4.0')
@@ -42,7 +40,6 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+if [ ! -z "$USER" ]; then echo "yes"; fi


### PR DESCRIPTION
This PR retires Python 2 by removing all references to it and removing it from the Travis test matrix.

I've also updated the README to reflect the latest tested versions, as well as the Django documentation.

Fixes #45 .