### PR TITLE
Add source snippets to backtrace lines

### DIFF
--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -43,12 +43,12 @@ def error_payload(exception, exc_traceback, config):
 
     return payload
 
-def read_source(line, source_radius=3):
-    if os.path.isfile(line[0]):
-        with open(line[0], 'rt', encoding='utf-8') as f:
+def read_source(frame, source_radius=3):
+    if os.path.isfile(frame[0]):
+        with open(frame[0], 'rt', encoding='utf-8') as f:
             contents = f.readlines()
 
-        index = min(max(line[1], source_radius), len(contents) - source_radius)
+        index = min(max(frame[1], source_radius), len(contents) - source_radius)
         return dict(zip(range(index-source_radius+1, index+source_radius+2), contents[index-source_radius:index+source_radius+1]))
 
     return {}

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -33,26 +33,25 @@ def error_payload(exception, exc_traceback, config):
     else:
         tb = [f for f in traceback.extract_stack() if is_not_honeybadger_frame(f)]
 
-    source_radius = 3 # configurable later...
-
     logger.debug(tb)
 
     payload = {
         'class': type(exception) is dict and exception['error_class'] or exception.__class__.__name__,
         'message': type(exception) is dict and exception['error_message'] or str(exception),
-        'backtrace': [dict(number=f[1], file=_filename(f[0]), method=f[2]) for f in reversed(tb)],
-        'source': {}
+        'backtrace': [dict(number=f[1], file=_filename(f[0]), method=f[2], source=read_source(f)) for f in reversed(tb)]
     }
-
-    if len(tb) > 0 and os.path.isfile(tb[-1][0]):
-        with open(tb[-1][0], 'rt', encoding='utf-8') as f:
-            contents = f.readlines()
-
-        index = min(max(tb[-1][1], source_radius), len(contents) - source_radius)
-        payload['source'] = dict(zip(range(index-source_radius+1, index+source_radius+2), contents[index-source_radius:index+source_radius+1]))
 
     return payload
 
+def read_source(line, source_radius=3):
+    if os.path.isfile(line[0]):
+        with open(line[0], 'rt', encoding='utf-8') as f:
+            contents = f.readlines()
+
+        index = min(max(line[1], source_radius), len(contents) - source_radius)
+        return dict(zip(range(index-source_radius+1, index+source_radius+2), contents[index-source_radius:index+source_radius+1]))
+
+    return {}
 
 def server_payload(config):
     payload = {

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -41,7 +41,7 @@ def test_error_payload_source_line_top_of_file():
         payload = error_payload(dict(error_class='Exception', error_message='Test'), None, config)
         expected = dict(zip(range(1, 8), ["Line {}\n".format(x) for x in range(1, 8)]))
         eq_(traceback_mock.call_count, 1)
-        eq_(payload['source'], expected)
+        eq_(payload['backtrace'][0]['source'], expected)
 
 def test_error_payload_source_line_bottom_of_file():
     with mock_traceback(line_no=10) as traceback_mock:
@@ -49,7 +49,7 @@ def test_error_payload_source_line_bottom_of_file():
         payload = error_payload(dict(error_class='Exception', error_message='Test'), None, config)
         expected = dict(zip(range(5, 11), ["Line {}\n".format(x) for x in range(5, 11)]))
         eq_(traceback_mock.call_count, 1)
-        eq_(payload['source'], expected)
+        eq_(payload['backtrace'][0]['source'], expected)
 
 def test_error_payload_source_line_midfile():
     with mock_traceback(line_no=5) as traceback_mock:
@@ -57,7 +57,7 @@ def test_error_payload_source_line_midfile():
         payload = error_payload(dict(error_class='Exception', error_message='Test'), None, config)
         expected = dict(zip(range(3, 10), ["Line {}\n".format(x) for x in range(3, 10)]))
         eq_(traceback_mock.call_count, 1)
-        eq_(payload['source'], expected)
+        eq_(payload['backtrace'][0]['source'], expected)
 
 
 @patch('os.path.isfile', return_value=False)
@@ -66,7 +66,7 @@ def test_error_payload_source_missing_file(_isfile):
         config = Configuration()
         payload = error_payload(
             dict(error_class='Exception', error_message='Test'), None, config)
-        eq_(payload['source'], {})
+        eq_(payload['backtrace'][0]['source'], {})
 
 
 def test_server_payload():


### PR DESCRIPTION
Instead of sending the snippet for just the first line (deprecated in our API), this adds a snippet for each line of the backtrace.