### PR TITLE
Fixes load avg bug on Windows

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
         env:
           - DJANGO_VERSION=1.11.29

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,11 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
         env:
           - DJANGO_VERSION=1.11.29

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -64,7 +64,7 @@ def server_payload(config):
     }
 
     s = psutil.virtual_memory()
-    loadavg = os.getloadavg()
+    loadavg = psutil.getloadavg()
 
     free = float(s.free) / 1048576.0
     buffers = hasattr(s, 'buffers') and float(s.buffers) / 1048576.0 or 0.0


### PR DESCRIPTION
Fixes #36 - swaps out the builtin `os.getloadavg()` for `psutil.getloadavg()` which is supported on both Windows and Linux.