### PR TITLE
get GH actions tests passing

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,12 +31,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
+      env: ${{ matrix.env }}
       run: |
         python -m pip install --upgrade pip
         pip install psutil six mock
         ./scripts/install_frameworks.sh
         python setup.py develop
     - name: Run Tests
+      env: ${{ matrix.env }}
       run: |
         export ${{ matrix.env }}
         python setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
         env:
-          - DJANGO_VERSION=1.11.29
-          - DJANGO_VERSION=2.2.11
-          - DJANGO_VERSION=3.0.4
-          - FLASK_VERSION=1.0.4
-          - FLASK_VERSION=1.1.1
+          - DJANGO_VERSION: 1.11.29
+          - DJANGO_VERSION: 2.2.11
+          - DJANGO_VERSION: 3.0.4
+          - FLASK_VERSION: 1.0.4
+          - FLASK_VERSION: 1.1.1
         exclude:
           - python-version: 3.5
-            env: DJANGO_VERSION=3.0.4
+            env: DJANGO_VERSION: 3.0.4
 
     steps:
     - uses: actions/checkout@v2
@@ -40,5 +40,4 @@ jobs:
     - name: Run Tests
       env: ${{ matrix.env }}
       run: |
-        export ${{ matrix.env }}
         python setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
         env:
-          - DJANGO_VERSION: 1.11.29
-          - DJANGO_VERSION: 2.2.11
-          - DJANGO_VERSION: 3.0.4
-          - FLASK_VERSION: 1.0.4
-          - FLASK_VERSION: 1.1.1
+          - DJANGO_VERSION=1.11.29
+          - DJANGO_VERSION=2.2.11
+          - DJANGO_VERSION=3.0.4
+          - FLASK_VERSION=1.0.4
+          - FLASK_VERSION=1.1.1
         exclude:
           - python-version: 3.5
-            env: "DJANGO_VERSION=3.0.4"
+            env: DJANGO_VERSION=3.0.4
 
     steps:
     - uses: actions/checkout@v2
@@ -31,13 +31,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
-      env: ${{ matrix.env }}
       run: |
+        export ${{ matrix.env }}
         python -m pip install --upgrade pip
         pip install psutil six mock
         ./scripts/install_frameworks.sh
         python setup.py develop
     - name: Run Tests
-      env: ${{ matrix.env }}
       run: |
+        export ${{ matrix.env }}
         python setup.py test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,8 @@ jobs:
           - FLASK_VERSION: 1.1.1
         exclude:
           - python-version: 3.5
-            env: DJANGO_VERSION: 3.0.4
+            env: 
+              - DJANGO_VERSION: 3.0.4
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,8 +22,7 @@ jobs:
           - FLASK_VERSION: 1.1.1
         exclude:
           - python-version: 3.5
-            env: 
-              - DJANGO_VERSION: 3.0.4
+            env: "DJANGO_VERSION=3.0.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/scripts/install_frameworks.sh
+++ b/scripts/install_frameworks.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -ev
 
-echo $DJANGO_VERSION
-echo $FLASK_VERSION
-
 [ ! -z "$DJANGO_VERSION" ] && pip install Django==$DJANGO_VERSION
 [ ! -z "$FLASK_VERSION" ] && pip install Flask==$FLASK_VERSION
 echo "OK"

--- a/scripts/install_frameworks.sh
+++ b/scripts/install_frameworks.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -ev
+
+echo $DJANGO_VERSION
+echo $FLASK_VERSION
+
 [ ! -z "$DJANGO_VERSION" ] && pip install Django==$DJANGO_VERSION
 [ ! -z "$FLASK_VERSION" ] && pip install Flask==$FLASK_VERSION
 echo "OK"

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')
     # For some reason, Flask 1.1.1 is pulling in Jinja2 3.0.0 which causes syntax errors.
     tests_require.append('Jinja2<3.0.0')
+    tests_require.append('MarkupSafe<2.0.0')
 
 if sys.version_info[0:2] <= (3, 5):
     tests_require.append('Django>=1.11,<=2.2')

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ tests_require = ['nose', 'mock', 'testfixtures', 'blinker']
 
 if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')
+    # For some reason, Flask 1.1.1 is pulling in Jinja2 3.0.0 which causes syntax errors.
+    tests_require.append('Jinja2<3.0.0')
 
 if sys.version_info[0:2] <= (3, 5):
     tests_require.append('Django>=1.11,<=2.2')

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,6 @@ tests_require = ['nose', 'mock', 'testfixtures', 'blinker']
 
 if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')
-    # For some reason, Flask 1.1.1 is pulling in Jinja2 3.0.0 which causes syntax errors.
-    tests_require.append('Jinja2<3.0.0')
 
 if sys.version_info[0:2] <= (3, 5):
     tests_require.append('Django>=1.11,<=2.2')


### PR DESCRIPTION
Added an environment export to the install dependencies step, and added a version constraint to the MarkupSafe dependency so that all tests pass on Github Actions.