### PR TITLE
Make psutil optional for use in serverless environments

### DIFF
--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -2,6 +2,7 @@ from six.moves import range
 from six.moves import zip
 from contextlib import contextmanager
 import os
+import sys
 
 from honeybadger.payload import error_payload
 from honeybadger.payload import server_payload
@@ -79,3 +80,10 @@ def test_server_payload():
     eq_(payload['pid'], os.getpid())
     assert type(payload['stats']['mem']['total']) == float
     assert type(payload['stats']['mem']['free']) == float
+
+def test_psutil_is_optional():
+    config = Configuration()
+
+    with patch.dict(sys.modules, {'psutil':None}):
+        payload = server_payload(config)
+        eq_(payload['stats'], {})


### PR DESCRIPTION
It's difficult or impossible to install psutil in an AWS Glue environment. This PR makes it so psutil is still a dependency, but those of us using it in a serverless environment that doesn't work well with psutil can explicitly exclude it, while still using honeybadger-python.

Fixes #62

Example of an error reported from AWS Glue:

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/1191305/104823464-336a5c80-5818-11eb-8653-3fe79d599f95.png">
