### PR TITLE
fixed wrong getattr statement

### DIFF
--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -81,7 +81,11 @@ class DjangoPlugin(Plugin):
         if hasattr(request, 'session'):
             payload['session'] = filter_dict(dict(request.session), config.params_filters)
 
-        payload['params'] = filter_dict(dict(getattr(request, request.method)), config.params_filters)
+        if request.method == 'GET':
+            payload['params'] = filter_dict(dict(request.GET), config.params_filters)
+            
+        else:
+            payload['params'] = filter_dict(dict(request.POST), config.params_filters)
 
         return payload
 


### PR DESCRIPTION
Django's request parameters is always found in request.GET for get requests and request.POST for PATCH & PUT requests.
attributes for other request method does not exist in the request object.