### PR TITLE
filter sensitive headers & cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-#### Added
-- Added 'CSRF_COOKIE' to default filter_params(#44)
-- Added HTTP_COOKIE to payload for flask & django(#44)
-- Added filtering meta attributes for flask & django(#43)
+### Added
+- Add `CSRF_COOKIE` to default filter_params (#44)
+- Add `HTTP_COOKIE` to payload for flask & django (#44)
+- Filter meta (cgi_data) attributes for flask & django (#43)
 
 ## [0.4.2] - 2021-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Added
+- Added 'CSRF_COOKIE' to default filter_params(#44)
+- Added HTTP_COOKIE to payload for flask & django(#44)
+- Added filtering meta attributes for flask & django(#43)
 
 ## [0.4.2] - 2021-02-04
 ### Fixed

--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -22,7 +22,7 @@ class Configuration(object):
         self.environment = 'production'
         self.hostname = socket.gethostname()
         self.endpoint = 'https://api.honeybadger.io'
-        self.params_filters = ['password', 'password_confirmation', 'credit_card']
+        self.params_filters = ['password', 'password_confirmation', 'credit_card', 'CSRF_COOKIE']
         self.force_report_data = False
 
         self.set_12factor_config()

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -87,6 +87,8 @@ class DjangoPlugin(Plugin):
         if request.method == 'GET':
             payload['params'] = filter_dict(dict(request.GET), config.params_filters)
             
+        else:
+            payload['params'] = filter_dict(dict(request.POST), config.params_filters)
 
         return payload
 

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -74,18 +74,19 @@ class DjangoPlugin(Plugin):
             'action': request.resolver_match.func.__name__,
             'params': {},
             'session': {},
-            'cgi_data': dict(request.META),
+            'cgi_data': filter_dict(request.META, config.params_filters),
             'context': context
         }
 
         if hasattr(request, 'session'):
             payload['session'] = filter_dict(dict(request.session), config.params_filters)
 
+        if hasattr(request, 'COOKIES'):
+            payload['cgi_data']['COOKIES'] = filter_dict(request.COOKIES, config.params_filters)
+
         if request.method == 'GET':
             payload['params'] = filter_dict(dict(request.GET), config.params_filters)
             
-        else:
-            payload['params'] = filter_dict(dict(request.POST), config.params_filters)
 
         return payload
 

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -82,7 +82,7 @@ class DjangoPlugin(Plugin):
             payload['session'] = filter_dict(dict(request.session), config.params_filters)
 
         if hasattr(request, 'COOKIES'):
-            payload['cgi_data']['COOKIES'] = filter_dict(request.COOKIES, config.params_filters)
+            payload['cgi_data']['HTTP_COOKIE'] = filter_dict(request.COOKIES, config.params_filters)
 
         if request.method == 'GET':
             payload['params'] = filter_dict(dict(request.GET), config.params_filters)

--- a/honeybadger/contrib/flask.py
+++ b/honeybadger/contrib/flask.py
@@ -52,7 +52,7 @@ class FlaskPlugin(Plugin):
         }
         cgi_data.update({
             'REQUEST_METHOD': _request.method,
-            'COOKIES': _request.cookies
+            'COOKIES': dict(_request.cookies)
         })
         payload = {
             'url': _request.base_url,

--- a/honeybadger/contrib/flask.py
+++ b/honeybadger/contrib/flask.py
@@ -51,7 +51,8 @@ class FlaskPlugin(Plugin):
             for k, v in iteritems(_request.headers)
         }
         cgi_data.update({
-            'REQUEST_METHOD': _request.method
+            'REQUEST_METHOD': _request.method,
+            'COOKIES': _request.cookies
         })
         payload = {
             'url': _request.base_url,
@@ -59,7 +60,7 @@ class FlaskPlugin(Plugin):
             'action': _request.endpoint,
             'params': {},
             'session': filter_dict(dict(session), config.params_filters),
-            'cgi_data': cgi_data,
+            'cgi_data': filter_dict(cgi_data, config.params_filters),
             'context': context
         }
 

--- a/honeybadger/contrib/flask.py
+++ b/honeybadger/contrib/flask.py
@@ -52,7 +52,7 @@ class FlaskPlugin(Plugin):
         }
         cgi_data.update({
             'REQUEST_METHOD': _request.method,
-            'COOKIES': dict(_request.cookies)
+            'HTTP_COOKIE' : dict(_request.cookies)
         })
         payload = {
             'url': _request.base_url,

--- a/honeybadger/tests/contrib/test_flask.py
+++ b/honeybadger/tests/contrib/test_flask.py
@@ -97,7 +97,7 @@ class FlaskPluginTestCase(unittest.TestCase):
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Content-Length': '29',
                 'REQUEST_METHOD': 'POST',
-                'COOKIES': {}
+                'HTTP_COOKIE': {}
             })
             self.assertDictEqual(payload['context'], {'k': 'value'})
 
@@ -117,7 +117,7 @@ class FlaskPluginTestCase(unittest.TestCase):
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Content-Length': '29',
                 'REQUEST_METHOD': 'PUT',
-                'COOKIES': {}
+                'HTTP_COOKIE': {}
             })
             self.assertDictEqual(payload['context'], {'k': 'value'})
 

--- a/honeybadger/tests/contrib/test_flask.py
+++ b/honeybadger/tests/contrib/test_flask.py
@@ -115,7 +115,8 @@ class FlaskPluginTestCase(unittest.TestCase):
                 'Host': 'server:1234',
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Content-Length': '29',
-                'REQUEST_METHOD': 'PUT'
+                'REQUEST_METHOD': 'PUT',
+                'COOKIES': {}
             })
             self.assertDictEqual(payload['context'], {'k': 'value'})
 

--- a/honeybadger/tests/contrib/test_flask.py
+++ b/honeybadger/tests/contrib/test_flask.py
@@ -96,7 +96,8 @@ class FlaskPluginTestCase(unittest.TestCase):
                 'Host': 'server:1234',
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Content-Length': '29',
-                'REQUEST_METHOD': 'POST'
+                'REQUEST_METHOD': 'POST',
+                'COOKIES': {}
             })
             self.assertDictEqual(payload['context'], {'k': 'value'})
 


### PR DESCRIPTION
- Added 'CSRF_COOKIE' to default filter_params
- Added filtering to meta attributes for flask or & django
- Added filtered cookies to cgi_data for flask & django
- removed conversion of request.META to dict because it is a dict by default

Fixes #43 
Fixes #44