### PR TITLE
fix: fastapi dependency issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,14 @@ A custom API Route is available at [`honeybadger.contrib.fastapi`](./honeybadger
 
 ```python
 from fastapi import FastAPI, APIRouter
-from honeybadger import honeybadger, contrib
+from honeybadger import honeybadger
+from honeybadger.contrib.fastapi import HoneybadgerRoute
 
 honeybadger.configure(api_key="<your-api-key>")
 app = FastAPI()
-app.router.route_class = contrib.HoneybadgerRoute
+app.router.route_class = HoneybadgerRoute
 
-router = APIRouter(route_class=contrib.HoneybadgerRoute)
+router = APIRouter(route_class=HoneybadgerRoute)
 
 ```
 

--- a/honeybadger/contrib/__init__.py
+++ b/honeybadger/contrib/__init__.py
@@ -2,12 +2,10 @@ from honeybadger.contrib.flask import FlaskHoneybadger
 from honeybadger.contrib.django import DjangoHoneybadgerMiddleware
 from honeybadger.contrib.aws_lambda import AWSLambdaPlugin
 from honeybadger.contrib.asgi import ASGIHoneybadger
-from honeybadger.contrib.fastapi import HoneybadgerRoute
 
 __all__ = [
     'FlaskHoneybadger',
     'DjangoHoneybadgerMiddleware',
     'AWSLambdaPlugin',
     'ASGIHoneybadger',
-    'HoneybadgerRoute'
 ]

--- a/honeybadger/tests/contrib/test_fastapi.py
+++ b/honeybadger/tests/contrib/test_fastapi.py
@@ -1,7 +1,7 @@
 import unittest
 import aiounittest
 import mock
-from honeybadger import contrib
+from honeybadger.contrib.fastapi import HoneybadgerRoute
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 class FastAPITestCase(unittest.TestCase):
     def setUp(self):
         app = FastAPI()
-        app.router.route_class = contrib.HoneybadgerRoute
+        app.router.route_class = HoneybadgerRoute
 
         @app.get("/ok")
         def ok_route():


### PR DESCRIPTION
Hello,
I just noticed that with #84 I introduced a dependency issue with fastapi preventing the correct initialization of Honeybadger.

This was caused by the `auto_discover_plugins` functionality importing the `contrib` package, and therefore raising an error when `fastapi` is not installed in your environment.

This pull request fixes that issue, and requires explicitly importing the `HoneybadgerRoute` for the "advanced" `apiRoute` usage in FastAPI.

(The tests completed successfully because `fastapi` is a dependency in the test environment).

What do you think? Does this makes sense to you, @Kelvin4664 ?

Thank you!