### PR TITLE
Add ability to ignore notifying on certain exceptions in django

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ HONEYBADGER = {
 }
 ```
 
+To prevent honeybadger from notifying you on certain errors (like an `Http404` exception), you can add the full path to the exception you would like to ignore to `HONEYBADGER_IGNORED_EXCEPTIONS` in settings:
+
+```python
+HONEYBADGER_IGNORED_EXCEPTIONS = ('django.http.response.Http404',)
+```
+
 ### Flask
 
 A Flask extension is available for initializing and configuring Honeybadger: `honeybadger.contrib.flask.FlaskHoneybadger`. The extension adds the following information to reported exceptions:

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -118,6 +118,14 @@ class DjangoHoneybadgerMiddleware(object):
         return response
 
     def process_exception(self, request, exception):
+        from django.conf import settings
+        ignored_exceptions = getattr(settings, "HONEYBADGER_IGNORED_EXCEPTIONS", None)
+
+        if ignored_exceptions:
+            name = f"{exception.__class__.__module__}.{exception.__class__.__qualname__}"
+            if name in ignored_exceptions:
+                return None
+
         honeybadger.notify(exception)
         clear_request()
         return None


### PR DESCRIPTION
Looks like something like this already exists [for ruby](https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-by-class), but is missing for python/django. Tried to find an alternative way to do this before opening the PR. Will close if there are better existing ways to do this for django.