### PR TITLE
feat: allow passing fingerprint in notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow passing fingerprint in `notify()` (#115)
 
 ## [0.9.0] - 2022-08-18
 ### Added

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -31,7 +31,7 @@ def error_payload(exception, exc_traceback, config, context=None):
             'message': type(exception) is dict and exception['error_message'] or str(exception),
             'backtrace': [dict(number=f[1], file=_filename(f[0]), method=f[2], source=read_source(f)) for f in reversed(tb)],
         }
-        fingerprint = type(context) is dict and context.get('fingerprint')
+        fingerprint = type(context) is dict and context.pop('fingerprint', None)
         result['fingerprint'] = fingerprint and str(fingerprint).strip() or None
 
         return result

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -85,11 +85,29 @@ def test_error_payload_with_nested_exception():
         exception_cause = Exception('Exception cause')
         exception_cause.__cause__ = Exception('Nested')
         exception.__cause__ = exception_cause
-
         payload = error_payload(exc_traceback=None, exception=exception,  config=config)
         eq_(len(payload['causes']), 2)
 
+def test_error_payload_with_fingerprint():
+    config = Configuration()
+    exception = Exception('Test')
+    context = {'fingerprint': 'a fingerprint'}
+    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    eq_(payload['fingerprint'], 'a fingerprint')
 
+def test_error_payload_with_fingerprint_as_type():
+    config = Configuration()
+    exception = Exception('Test')
+    context = {'fingerprint': {'a': 1, 'b': 2}}
+    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    eq_(payload['fingerprint'], "{'a': 1, 'b': 2}")
+
+def test_error_payload_without_fingerprint():
+    config = Configuration()
+    exception = Exception('Test')
+    context = {}
+    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    eq_(payload['fingerprint'], None)
 
 def test_server_payload():
     config = Configuration(project_root=os.path.dirname(__file__), environment='test', hostname='test.local')


### PR DESCRIPTION
Fixes #115

Allow passing fingerprint in `notify()` through the `context` parameter.