### PR TITLE
fix: make fingerprint a top-level parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Make fingerprint a top-level function parameter (#115)
 
 ## [0.10.0] - 2022-09-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ honeybadger.configure(api_key='myapikey', project_root='/home/dave/crywolf-djang
 In cases where you'd like to manually send error notices to Honeybadger, this is what you're looking for. You can either pass it an exception as the first argument, or an `error_class`/`error_message` pair of keyword arguments.
 You can also pass it a:
 - custom context dictionary which will get merged with the global context
-- a `fingerprint` to customize the [error grouping](https://docs.honeybadger.io/guides/errors/#error-grouping)
+- `fingerprint` option to customize the [error grouping](https://docs.honeybadger.io/guides/errors/#error-grouping)
 
 #### Examples:
 

--- a/README.md
+++ b/README.md
@@ -386,8 +386,10 @@ honeybadger.configure(api_key='myapikey', project_root='/home/dave/crywolf-djang
 
 ### `honeybadger.notify`: Send an error notice to Honeybadger
 
-In cases where you'd like to manually send error notices to Honeybadger, this is what you're looking for. You can either pass it an exception as the first argument, or an `error_class`/`error_message` pair of keyword arguments. You can also pass it a custom context dictionary which will get merged with the global context.
-Optionally, add a `fingerprint` key to customize the [error grouping](https://docs.honeybadger.io/guides/errors/#error-grouping).
+In cases where you'd like to manually send error notices to Honeybadger, this is what you're looking for. You can either pass it an exception as the first argument, or an `error_class`/`error_message` pair of keyword arguments.
+You can also pass it a:
+- custom context dictionary which will get merged with the global context
+- a `fingerprint` to customize the [error grouping](https://docs.honeybadger.io/guides/errors/#error-grouping)
 
 #### Examples:
 
@@ -400,7 +402,7 @@ except KeyError, exc:
   honeybadger.notify(exc, context={'foo': 'bar'})
 
 # with custom arguments
-honeybadger.notify(error_class='ValueError', error_message='Something bad happened!', context={'fingerprint': 'custom_fingerprint'})
+honeybadger.notify(error_class='ValueError', error_message='Something bad happened!', fingerprint='custom_fingerprint')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ honeybadger.configure(api_key='myapikey', project_root='/home/dave/crywolf-djang
 ### `honeybadger.notify`: Send an error notice to Honeybadger
 
 In cases where you'd like to manually send error notices to Honeybadger, this is what you're looking for. You can either pass it an exception as the first argument, or an `error_class`/`error_message` pair of keyword arguments. You can also pass it a custom context dictionary which will get merged with the global context.
+Optionally, add a `fingerprint` key to customize the [error grouping](https://docs.honeybadger.io/guides/errors/#error-grouping).
 
 #### Examples:
 
@@ -399,7 +400,7 @@ except KeyError, exc:
   honeybadger.notify(exc, context={'foo': 'bar'})
 
 # with custom arguments
-honeybadger.notify(error_class='ValueError', error_message='Something bad happened!')
+honeybadger.notify(error_class='ValueError', error_message='Something bad happened!', context={'fingerprint': 'custom_fingerprint'})
 ```
 
 ## Development

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -91,22 +91,19 @@ def test_error_payload_with_nested_exception():
 def test_error_payload_with_fingerprint():
     config = Configuration()
     exception = Exception('Test')
-    context = {'fingerprint': 'a fingerprint'}
-    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    payload = error_payload(exception, exc_traceback=None, config=config, fingerprint='a fingerprint')
     eq_(payload['fingerprint'], 'a fingerprint')
 
 def test_error_payload_with_fingerprint_as_type():
     config = Configuration()
     exception = Exception('Test')
-    context = {'fingerprint': {'a': 1, 'b': 2}}
-    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    payload = error_payload(exception, exc_traceback=None, config=config, fingerprint={'a': 1, 'b': 2})
     eq_(payload['fingerprint'], "{'a': 1, 'b': 2}")
 
 def test_error_payload_without_fingerprint():
     config = Configuration()
     exception = Exception('Test')
-    context = {}
-    payload = error_payload(exception, exc_traceback=None, config=config, context=context)
+    payload = error_payload(exception, exc_traceback=None, config=config)
     eq_(payload['fingerprint'], None)
 
 def test_server_payload():

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -104,7 +104,7 @@ def test_error_payload_without_fingerprint():
     config = Configuration()
     exception = Exception('Test')
     payload = error_payload(exception, exc_traceback=None, config=config)
-    eq_(payload['fingerprint'], None)
+    eq_(payload.get('fingerprint'), None)
 
 def test_server_payload():
     config = Configuration(project_root=os.path.dirname(__file__), environment='test', hostname='test.local')


### PR DESCRIPTION
- Makes `fingerprint` a top-level function parameter 
- Adds example using `fingerprint`