### PR TITLE
chore: add httpx dep to fix ci

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from codecs import open
 from setuptools import setup
 
-tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'async-asgi-testclient', 'aiounittest', 'fastapi']
+tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'async-asgi-testclient', 'aiounittest', 'fastapi', 'httpx']
 
 if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')


### PR DESCRIPTION
Per this [issue](https://github.com/tiangolo/fastapi/issues/5656), we need to add the httpx dependency with the latest version of fastapi.