### PR TITLE
Fix django with custom middlewares

### DIFF
--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -66,12 +66,19 @@ class DjangoPlugin(Plugin):
         :param config: honeybadger configuration.
         :return: a dict with the generated payload.
         """
-        request = current_request()
+        import django
+        if django.VERSION[0] < 2:
+            from django.core.urlresolvers import resolve
+        else:
+            from django.urls import resolve
 
+
+        request = current_request()
+        resolver_match = request.resolver_match or resolve(request.path_info)
         request_payload = {
             'url': request.build_absolute_uri(),
-            'component': request.resolver_match.app_name,
-            'action': request.resolver_match.func.__name__,
+            'component': resolver_match.app_name,
+            'action': resolver_match.func.__name__,
             'params': {},
             'session': {},
             'cgi_data': filter_dict(request.META, config.params_filters),

--- a/honeybadger/tests/contrib/django_test_app/middleware.py
+++ b/honeybadger/tests/contrib/django_test_app/middleware.py
@@ -1,0 +1,6 @@
+from django.utils.deprecation import MiddlewareMixin
+from honeybadger import honeybadger
+
+class CustomMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        honeybadger.notify("Custom Middleware Exception")


### PR DESCRIPTION
Honeybadger crashes when it tries to notify inside a custom Django middleware as the `request.resolver_match` is `None`.