### PR TITLE
Jettison Python 3.7 as it won't work with Django 4

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,21 +13,25 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
         env:
           - DJANGO_VERSION=1.11.29
-          - DJANGO_VERSION=2.2.11
-          - DJANGO_VERSION=3.0.4
+          - DJANGO_VERSION=2.2.28
+          - DJANGO_VERSION=3.2.19
+          - DJANGO_VERSION=4.2.1
           - FLASK_VERSION=1.0.4
           - FLASK_VERSION=1.1.1
 
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Check out ${{ github.ref }}
+      uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install Dependencies
       run: |
         export ${{ matrix.env }}
@@ -35,6 +39,7 @@ jobs:
         pip install psutil six mock itsdangerous nose testfixtures blinker wheel
         ./scripts/install_frameworks.sh
         python setup.py develop
+
     - name: Run Tests
       run: |
         export ${{ matrix.env }}


### PR DESCRIPTION
 - add build target for Django 4.2LTS
 - also update 2.2 & 3.2 LTS revs
 - upate actions to use Node.js 16