### PR TITLE
Latest Celery 5.3 breaks unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import os
 from codecs import open
 from setuptools import setup
 
-tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'async-asgi-testclient', 'aiounittest', 'fastapi', 'httpx', 'celery', 'importlib-metadata==4.8.3']
+tests_require = ['nose', 'mock', 'testfixtures', 'blinker', 'async-asgi-testclient',
+                 'aiounittest', 'fastapi', 'httpx', 'celery==5.2.*', 'importlib-metadata==4.8.3']
 
 if sys.version_info[0:2] >= (3, 5):
     tests_require.append('Flask>=1.0')


### PR DESCRIPTION
Recent release of Celery 5.3 broke CI. This hack pins it to 5.2.