### PR TITLE
feat(aws-lambda): add support for python 3.9+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,11 @@ fabric.properties
 # .idea/misc.xml
 # *.ipr
 
+.idea
+
 # Sonarlint plugin
 .idea/sonarlint
+
+
+.tool-versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ## [0.18.0] - 2024-01-12
-- AWS Lambda: Support for Python 3.9
+- AWS Lambda: Support for Python 3.9+
 
 ## [0.17.0] - 2023-07-27
 - Django: Automatically capture user id and user name when available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ## [0.18.0] - 2024-01-12
+- AWS Lambda: Support for Python 3.9
 
 ## [0.17.0] - 2023-07-27
 - Django: Automatically capture user id and user name when available

--- a/README.md
+++ b/README.md
@@ -436,11 +436,23 @@ honeybadger.notify(error_class='ValueError', error_message='Something bad happen
 
 ## Development
 
+### Python environment setup
+
+A simple way to setup a python environment is to use [asdf](https://asdf-vm.com/#/). After installing `asdf`, run the following commands:
+1. `asdf install python 3.9.16`
+2. `asdf local python 3.9.16`
+
+### Installing dependencies
+
+```sh
 After cloning the repo, run:
 
 ```sh
+pip install wheel
 python setup.py develop
 ```
+
+### Unit tests
 
 To run the unit tests:
 
@@ -469,6 +481,7 @@ See https://github.com/honeybadger-io/honeybadger-python/blob/master/CHANGELOG.m
 ### Github Workflow
 
 A new version can be published on PyPi using the [Publish new version on PyPi](.github/workflows/pypi-publish.yml) workflow.
+Before triggering the workflow, ensure that upcoming version changes in [CHANGELOG.md](./CHANGELOG.md) are recorded in the `Unreleased` section. 
 The workflow can be triggered manually from the Github Actions page and takes a version input.
 
 ### Manual Release 

--- a/honeybadger/contrib/aws_lambda.py
+++ b/honeybadger/contrib/aws_lambda.py
@@ -52,14 +52,23 @@ def reraise(tp, value, tb=None):
 def get_lambda_bootstrap():
     """
     Get AWS Lambda bootstrap module
-    """
 
+    First, we check for the presence of the bootstrap module in sys.modules.
+    If it's not there, we check for the presence of __main__.
+    In 3.8, the bootstrap module is imported as __main__.
+    In 3.9, the bootstrap module is imported as __main__.awslambdaricmain.
+    In some other cases, the bootstrap module is imported as __main__.bootstrap.
+    """
     if "bootstrap" in sys.modules:
         return sys.modules["bootstrap"]
     elif "__main__" in sys.modules:
-        if hasattr(sys.modules["__main__"], "bootstrap"):
-            return sys.modules["__main__"].bootstrap
-        return sys.modules["__main__"]
+        module = sys.modules["__main__"]
+        if hasattr(module, "awslambdaricmain") and hasattr(module.awslambdaricmain, "bootstrap"):
+            return module.awslambdaricmain.bootstrap
+        elif hasattr(module, "bootstrap"):
+            return module.bootstrap
+
+        return module
     else:
         return None
 


### PR DESCRIPTION
Closes: #159

Manually tested with python runtimes up to `3.12`.