### PR TITLE
fix(django): capture user name and id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Django: Fix for automatically capturing user id and user name when available
 
 ## [0.20.1] - 2024-06-14
 - Fix: Resolve "can't pickle '_io.TextIOWrapper' object" error (#173)

--- a/examples/django_app/honeybadger_example/settings.py
+++ b/examples/django_app/honeybadger_example/settings.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Honeybadger middleware goes to the top
+    'honeybadger.contrib.DjangoHoneybadgerMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -50,8 +52,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    # Add honeybadger middleware
-    'honeybadger.contrib.DjangoHoneybadgerMiddleware',
 ]
 
 ROOT_URLCONF = 'honeybadger_example.urls'

--- a/honeybadger/contrib/django.py
+++ b/honeybadger/contrib/django.py
@@ -116,7 +116,6 @@ class DjangoHoneybadgerMiddleware(object):
     def __call__(self, request):
         set_request(request)
         honeybadger.begin_request(request)
-        self.__set_user_from_context(request)
 
         response = self.get_response(request)
 
@@ -126,6 +125,7 @@ class DjangoHoneybadgerMiddleware(object):
         return response
 
     def process_exception(self, request, exception):
+        self.__set_user_from_context(request)
         honeybadger.notify(exception)
         clear_request()
         return None


### PR DESCRIPTION
Moves the `__set_user_from_context` method inside `process_exception` of the middleware definition.

More context on the fix:
- We [recommend](https://docs.honeybadger.io/lib/python/#django) to put Honeybadger's middleware at the top of the middleware list.
- When this middleware is executed, `request.user` is not set yet from the other middleware. The current approach was trying to set the user session before passing on to the other middleware.
- The solution is to move the method which sets the user into Honeybadger's context closer to the exception (`process_exception`). At that point, it is more probable to have the user session available if the proper middleware have been executed (i.e. `django.contrib.auth.middleware.AuthenticationMiddleware`).

Fixes: #155