### PR TITLE
Syntax error in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ You can also pass it a:
 mydict = dict(a=1)
 try:
   print mydict['b']
-except KeyError, exc:
+except KeyError as exc:
   honeybadger.notify(exc, context={'foo': 'bar'})
 
 # with custom arguments


### PR DESCRIPTION
Hi there :wave: 

```
>>> try:
...     int("asd")
... except ValueError, e:
  File "<stdin>", line 3
    except ValueError, e:
           ^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

Another thing: Since `exception` is really a keyword argument, perhaps the documented way to call `notify()` should be `notify(exception=exc, ...)` ?