### PR TITLE
fix(events): `event_type` is not required

### DIFF
--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -26,7 +26,7 @@ class Honeybadger(object):
             return fake_connection.send_notice(self.config, payload)
         else:
             return connection.send_notice(self.config, payload)
-        
+
     def _send_event(self, payload):
         if self.config.is_dev() and not self.config.force_report_data:
             return fake_connection.send_event(self.config, payload)
@@ -62,11 +62,10 @@ class Honeybadger(object):
             merged_context.update(context)
 
         return self._send_notice(exception, context=merged_context, fingerprint=fingerprint)
-    
-    
+
     def event(self, event_type=None, data=None, **kwargs):
         """
-        Send an event to Honeybadger
+        Send an event to Honeybadger.
         Events logged with this method will appear in Honeybadger Insights.
         """
         # If the first argument is a string, treat it as event_type
@@ -80,10 +79,6 @@ class Honeybadger(object):
         # Raise an error if event_type is not provided correctly
         else:
             raise ValueError("The first argument must be either a string or a dictionary")
-
-        # Ensure 'event_type' is in payload
-        if 'event_type' not in payload:
-            raise ValueError("An event_type must be provided")
 
         # Add a timestamp to the payload if not provided
         if 'ts' not in payload:

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -142,3 +142,41 @@ def test_notify_context_merging():
         hb.configure(api_key='aaa', force_report_data=True)
         hb.set_context(foo='bar')
         hb.notify(error_class='Exception', error_message='Test.', context=dict(bar='foo'))
+
+def test_event_with_two_params():
+    def test_payload(request):
+        payload = json.loads(request.data.decode('utf-8'))
+        assert 'ts' in payload
+        eq_(payload['event_type'], 'order.completed')
+        eq_(payload['email'], 'user@example.com')
+
+    hb = Honeybadger()
+
+    with mock_urlopen(test_payload) as request_mock:
+        hb.configure(api_key='aaa', force_report_data=True)
+        hb.event(event_type='order.completed', data=dict(email='user@example.com'))
+
+def test_event_with_one_param():
+    def test_payload(request):
+        payload = json.loads(request.data.decode('utf-8'))
+        assert 'ts' in payload
+        eq_(payload['event_type'], 'order.completed')
+        eq_(payload['email'], 'user@example.com')
+
+    hb = Honeybadger()
+
+    with mock_urlopen(test_payload) as request_mock:
+        hb.configure(api_key='aaa', force_report_data=True)
+        hb.event(dict(event_type='order.completed', email='user@example.com'))
+
+def test_event_without_event_type():
+    def test_payload(request):
+        payload = json.loads(request.data.decode('utf-8'))
+        assert 'ts' in payload
+        eq_(payload['email'], 'user@example.com')
+
+    hb = Honeybadger()
+
+    with mock_urlopen(test_payload) as request_mock:
+        hb.configure(api_key='aaa', force_report_data=True)
+        hb.event(dict(email='user@example.com'))


### PR DESCRIPTION
I looked into our other client integrations and `event_type` is not a required field, so I removed from here as well.
I also added a few tests.