### PR TITLE
feat: add a notice class and before_notify hook

### DIFF
--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -18,6 +18,7 @@ class Configuration(object):
         ("force_sync", bool),
         ("excluded_exceptions", list),
         ("report_local_variables", bool),
+        ("before_notify", callable),
         # Insights options
         ("events_batch_size", int),
         ("events_max_queue_size", int),
@@ -42,6 +43,7 @@ class Configuration(object):
         self.force_sync = self.is_aws_lambda_environment
         self.excluded_exceptions = []
         self.report_local_variables = False
+        self.before_notify = lambda notice: None
 
         self.events_max_batch_retries = 3
         self.events_max_queue_size = 10_000

--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -43,7 +43,7 @@ class Configuration(object):
         self.force_sync = self.is_aws_lambda_environment
         self.excluded_exceptions = []
         self.report_local_variables = False
-        self.before_notify = lambda notice: None
+        self.before_notify = lambda notice: notice
 
         self.events_max_batch_retries = 3
         self.events_max_queue_size = 10_000

--- a/honeybadger/connection.py
+++ b/honeybadger/connection.py
@@ -45,7 +45,11 @@ def _make_http_request(path, config, payload):
         t.start()
 
 
-def send_notice(config, payload):
+def send_notice(config, notice):
+    if notice.halted:
+        return
+
+    payload = notice.payload
     notice_id = payload.get("error", {}).get("token", None)
     path = "/v1/notices/"
     _make_http_request(path, config, payload)

--- a/honeybadger/connection.py
+++ b/honeybadger/connection.py
@@ -46,9 +46,6 @@ def _make_http_request(path, config, payload):
 
 
 def send_notice(config, notice):
-    if notice.halted:
-        return
-
     payload = notice.payload
     notice_id = payload.get("error", {}).get("token", None)
     path = "/v1/notices/"

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -36,7 +36,7 @@ class Honeybadger(object):
             except Exception as e:
                 logger.error("Error in before_notify callback: %s", e)
 
-        if notice is None:
+        if not isinstance(notice, Notice):
             logger.debug("Notice was filtered out by before_notify callback")
             return
 

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -15,6 +15,7 @@ from .config import Configuration
 from .notice import Notice
 
 logger = logging.getLogger("honeybadger")
+logger.addHandler(logging.NullHandler())
 
 
 class Honeybadger(object):

--- a/honeybadger/fake_connection.py
+++ b/honeybadger/fake_connection.py
@@ -3,13 +3,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def send_notice(config, payload):
+def send_notice(config, notice):
+    if notice.halted:
+        return
+
+    payload = notice.payload
     notice_id = payload.get("error", {}).get("token", None)
     logger.info(
         "Development mode is enabled; this error will be reported if it occurs after you deploy your app."
-    )
-    logger.debug(
-        "[send_notice] config used is {} with payload {}".format(config, payload)
     )
     return notice_id
 

--- a/honeybadger/fake_connection.py
+++ b/honeybadger/fake_connection.py
@@ -4,9 +4,6 @@ logger = logging.getLogger(__name__)
 
 
 def send_notice(config, notice):
-    if notice.halted:
-        return
-
     payload = notice.payload
     notice_id = payload.get("error", {}).get("token", None)
     logger.info(

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -1,0 +1,107 @@
+from functools import cached_property
+from .payload import create_payload
+
+
+class Notice(object):
+    def __init__(self, *args, **kwargs):
+        self._exception = kwargs.get("exception", None)
+        self._error_class = kwargs.get("error_class", None)
+        self._error_message = kwargs.get("error_message", None)
+        self._tags = kwargs.get("tags", None)
+        self._context = kwargs.get("context", None)
+        self._halted = False
+
+        self.exc_traceback = kwargs.get("exc_traceback", None)
+        self.fingerprint = kwargs.get("fingerprint", None)
+        self.thread_local = kwargs.get("thread_local", None)
+        self.config = kwargs.get("config", None)
+
+        if self._exception is None and self._error_class is None:
+            raise ValueError("Either exception or error_class must be provided")
+
+        if self.excluded_exception():
+            self._halted = True
+
+        self.payload = create_payload(
+            self.exception,
+            self.exc_traceback,
+            fingerprint=self.fingerprint,
+            context=self.context,
+            tags=self.tags,
+            config=self.config,
+        )
+
+    @property
+    def context(self):
+        merged_context = self._get_thread_context()
+        if self._context:
+            merged_context.update(self._context)
+        return merged_context
+
+    @property
+    def tags(self):
+        merged_context = self._get_thread_context()
+        tags_from_context = self._construct_tags(merged_context.get("_tags", []))
+        tags_from_args = self._construct_tags(self._tags or [])
+        return list(set(tags_from_context + tags_from_args))
+
+    @property
+    def notice_id(self):
+        return self.payload.get("error", {}).get("token", None)
+
+    @property
+    def exception(self):
+        if self._exception is None:
+            if self._error_class and self._error_message:
+                return {
+                    "error_class": self._error_class,
+                    "error_message": self._error_message,
+                }
+            else:
+                return None
+
+        return self._exception
+
+    @property
+    def halted(self):
+        return self._halted
+
+    @halted.setter
+    def halted(self, value):
+        if not isinstance(value, bool):
+            raise TypeError("halted must be a boolean")
+        self._halted = value
+
+    def excluded_exception(self):
+        if self.config.excluded_exceptions:
+            if (
+                self._exception
+                and self._exception.__class__.__name__
+                in self.config.excluded_exceptions
+            ):
+                return True
+            elif (
+                self._error_class
+                and self._error_class in self.config.excluded_exceptions
+            ):
+                return True
+        return False
+
+    def _get_thread_context(self):
+        if self.thread_local is None:
+            return {}
+        return getattr(self.thread_local, "context", {})
+
+    def _construct_tags(self, tags):
+        constructed_tags = []
+        if isinstance(tags, str):
+            constructed_tags = [tag.strip() for tag in tags.split(",")]
+        elif isinstance(tags, list):
+            constructed_tags = tags
+        return constructed_tags
+
+    def __getitem__(self, key):
+        return self.payload[key]
+
+    def __contains__(self, key):
+        return key in self.payload

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -4,25 +4,36 @@ from .payload import create_payload
 
 class Notice(object):
     def __init__(self, *args, **kwargs):
-        self._exception = kwargs.get("exception", None)
-        self._error_class = kwargs.get("error_class", None)
-        self._error_message = kwargs.get("error_message", None)
-        self._tags = kwargs.get("tags", None)
-        self._context = kwargs.get("context", None)
-        self._halted = False
+        self.exception = kwargs.get("exception", None)
+        self.error_class = kwargs.get("error_class", None)
+        self.error_message = kwargs.get("error_message", None)
+
+        if self.exception is None:
+            if self.error_class and self.error_message:
+                self.exception = {
+                    "error_class": self.error_class,
+                    "error_message": self.error_message,
+                }
+            else:
+                raise ValueError("Either exception or error_class must be provided")
 
         self.exc_traceback = kwargs.get("exc_traceback", None)
         self.fingerprint = kwargs.get("fingerprint", None)
         self.thread_local = kwargs.get("thread_local", None)
         self.config = kwargs.get("config", None)
 
-        if self._exception is None and self._error_class is None:
-            raise ValueError("Either exception or error_class must be provided")
+        self.context = self._get_thread_context()
+        self.context.update(kwargs.get("context", {}))
 
-        if self.excluded_exception():
-            self._halted = True
+        tags_from_context = self._construct_tags(
+            self._get_thread_context().get("_tags", [])
+        )
+        tags_from_args = self._construct_tags(kwargs.get("tags", []))
+        self.tags = list(set(tags_from_context + tags_from_args))
 
-        self.payload = create_payload(
+    @cached_property
+    def payload(self):
+        return create_payload(
             self.exception,
             self.exc_traceback,
             fingerprint=self.fingerprint,
@@ -31,58 +42,15 @@ class Notice(object):
             config=self.config,
         )
 
-    @property
-    def context(self):
-        merged_context = self._get_thread_context()
-        if self._context:
-            merged_context.update(self._context)
-        return merged_context
-
-    @property
-    def tags(self):
-        merged_context = self._get_thread_context()
-        tags_from_context = self._construct_tags(merged_context.get("_tags", []))
-        tags_from_args = self._construct_tags(self._tags or [])
-        return list(set(tags_from_context + tags_from_args))
-
-    @property
-    def notice_id(self):
-        return self.payload.get("error", {}).get("token", None)
-
-    @property
-    def exception(self):
-        if self._exception is None:
-            if self._error_class and self._error_message:
-                return {
-                    "error_class": self._error_class,
-                    "error_message": self._error_message,
-                }
-            else:
-                return None
-
-        return self._exception
-
-    @property
-    def halted(self):
-        return self._halted
-
-    @halted.setter
-    def halted(self, value):
-        if not isinstance(value, bool):
-            raise TypeError("halted must be a boolean")
-        self._halted = value
-
     def excluded_exception(self):
         if self.config.excluded_exceptions:
             if (
-                self._exception
-                and self._exception.__class__.__name__
-                in self.config.excluded_exceptions
+                self.exception
+                and self.exception.__class__.__name__ in self.config.excluded_exceptions
             ):
                 return True
             elif (
-                self._error_class
-                and self._error_class in self.config.excluded_exceptions
+                self.error_class and self.error_class in self.config.excluded_exceptions
             ):
                 return True
         return False
@@ -99,9 +67,3 @@ class Notice(object):
         elif isinstance(tags, list):
             constructed_tags = tags
         return constructed_tags
-
-    def __getitem__(self, key):
-        return self.payload[key]
-
-    def __contains__(self, key):
-        return key in self.payload

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -7,6 +7,7 @@ class Notice(object):
         self.exception = kwargs.get("exception", None)
         self.error_class = kwargs.get("error_class", None)
         self.error_message = kwargs.get("error_message", None)
+        self.context = {}
 
         if self.exception is None:
             if self.error_class and self.error_message:
@@ -16,13 +17,15 @@ class Notice(object):
                 }
             else:
                 raise ValueError("Either exception or error_class must be provided")
+        elif self.exception and self.error_message:
+            self.context["error_message"] = self.error_message
 
         self.exc_traceback = kwargs.get("exc_traceback", None)
         self.fingerprint = kwargs.get("fingerprint", None)
         self.thread_local = kwargs.get("thread_local", None)
         self.config = kwargs.get("config", None)
 
-        self.context = self._get_thread_context()
+        self.context.update(self._get_thread_context())
         self.context.update(kwargs.get("context", {}))
 
         tags_from_context = self._construct_tags(

--- a/honeybadger/tests/contrib/test_celery.py
+++ b/honeybadger/tests/contrib/test_celery.py
@@ -4,6 +4,8 @@ from celery import Celery
 from honeybadger import honeybadger
 from honeybadger.contrib.celery import CeleryHoneybadger
 
+import honeybadger.connection as connection
+
 
 class CeleryPluginTestCase(unittest.TestCase):
     def setUp(self):
@@ -17,16 +19,17 @@ class CeleryPluginTestCase(unittest.TestCase):
         )
         self.celery_hb = None
 
-    def get_mock_args(self, mock):
-        return mock.call_args[0][1]
+    def get_mock_notice_payload(self, mock):
+        return mock.call_args[0][1].payload
 
     def tearDown(self):
         super().tearDown()
         if self.celery_hb:
             self.celery_hb.tearDown()
 
-    @patch("honeybadger.connection.send_notice")
-    def test_celery_task_with_exception(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_celery_task_with_exception(self, mock, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
         @self.app.task
@@ -36,14 +39,15 @@ class CeleryPluginTestCase(unittest.TestCase):
         error.delay()
         mock.assert_called_once()
         self.assertEqual(
-            self.get_mock_args(mock)["error"]["class"], "ZeroDivisionError"
+            self.get_mock_notice_payload(mock)["error"]["class"], "ZeroDivisionError"
         )
         self.assertEqual(
-            self.get_mock_args(mock)["error"]["message"], "division by zero"
+            self.get_mock_notice_payload(mock)["error"]["message"], "division by zero"
         )
 
-    @patch("honeybadger.connection.send_notice")
-    def test_celery_task_with_params(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_celery_task_with_params(self, mock, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
         @self.app.task
@@ -52,13 +56,16 @@ class CeleryPluginTestCase(unittest.TestCase):
 
         error.delay(1, 0, c=3)
         mock.assert_called_once()
-        self.assertEqual(self.get_mock_args(mock)["request"]["params"]["args"], [1, 0])
         self.assertEqual(
-            self.get_mock_args(mock)["request"]["params"]["kwargs"], {"c": 3}
+            self.get_mock_notice_payload(mock)["request"]["params"]["args"], [1, 0]
+        )
+        self.assertEqual(
+            self.get_mock_notice_payload(mock)["request"]["params"]["kwargs"], {"c": 3}
         )
 
-    @patch("honeybadger.connection.send_notice")
-    def test_celery_task_without_retries(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_celery_task_without_retries(self, mock, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
         @self.app.task
@@ -67,13 +74,16 @@ class CeleryPluginTestCase(unittest.TestCase):
 
         error.delay()
         mock.assert_called_once()
-        self.assertEqual(self.get_mock_args(mock)["request"]["context"]["retries"], 0)
         self.assertEqual(
-            self.get_mock_args(mock)["request"]["context"]["max_retries"], 3
+            self.get_mock_notice_payload(mock)["request"]["context"]["retries"], 0
+        )
+        self.assertEqual(
+            self.get_mock_notice_payload(mock)["request"]["context"]["max_retries"], 3
         )
 
-    @patch("honeybadger.connection.send_notice")
-    def test_celery_task_with_retries(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_celery_task_with_retries(self, mock, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
         @self.app.task(bind=True, max_retries=5, autoretry_for=(ZeroDivisionError,))
@@ -82,14 +92,17 @@ class CeleryPluginTestCase(unittest.TestCase):
 
         error.delay()
         mock.assert_called_once()
-        self.assertEqual(self.get_mock_args(mock)["request"]["context"]["retries"], 5)
         self.assertEqual(
-            self.get_mock_args(mock)["request"]["context"]["max_retries"], 5
+            self.get_mock_notice_payload(mock)["request"]["context"]["retries"], 5
+        )
+        self.assertEqual(
+            self.get_mock_notice_payload(mock)["request"]["context"]["max_retries"], 5
         )
 
-    @patch("honeybadger.connection.send_notice")
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
     @patch("honeybadger.honeybadger.reset_context")
-    def test_celery_task_with_reset_context(self, mock_reset, mock_send):
+    def test_celery_task_with_reset_context(self, mock_reset, mock_send, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
         @self.app.task
@@ -100,8 +113,9 @@ class CeleryPluginTestCase(unittest.TestCase):
         mock_send.assert_called_once()
         mock_reset.assert_called_once()
 
-    @patch("honeybadger.connection.send_notice")
-    def test_without_auto_report_exceptions(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_without_auto_report_exceptions(self, mock, mock_request):
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=False)
 
         @self.app.task
@@ -111,8 +125,9 @@ class CeleryPluginTestCase(unittest.TestCase):
         error.delay()
         mock.assert_not_called()
 
-    @patch("honeybadger.connection.send_notice")
-    def test_context_merging(self, mock):
+    @patch("honeybadger.connection._make_http_request")
+    @patch("honeybadger.connection.send_notice", wraps=connection.send_notice)
+    def test_context_merging(self, mock, mock_request):
         """Test that custom context is merged with task context rather than being replaced"""
         self.celery_hb = CeleryHoneybadger(self.app, report_exceptions=True)
 
@@ -125,7 +140,7 @@ class CeleryPluginTestCase(unittest.TestCase):
         mock.assert_called_once()
 
         # Verify task context is present
-        context = self.get_mock_args(mock)["request"]["context"]
+        context = self.get_mock_notice_payload(mock)["request"]["context"]
         self.assertIn("task_id", context)
         self.assertIn("retries", context)
         self.assertIn("max_retries", context)

--- a/honeybadger/tests/test_config.py
+++ b/honeybadger/tests/test_config.py
@@ -64,3 +64,11 @@ def test_is_dev_false_for_non_dev_environments():
 def test_force_report_data_not_active():
     c = Configuration()
     assert c.force_report_data == False
+
+
+def test_configure_before_notify():
+    def before_notify_callback(notice):
+        return notice
+
+    c = Configuration(before_notify=before_notify_callback)
+    assert c.before_notify == before_notify_callback

--- a/honeybadger/tests/test_connection.py
+++ b/honeybadger/tests/test_connection.py
@@ -6,34 +6,39 @@ from .utils import mock_urlopen
 
 from honeybadger.connection import send_notice
 from honeybadger.config import Configuration
+from honeybadger.notice import Notice
 import uuid
 
 
 def test_connection_success():
     api_key = "badgerbadgermushroom"
-    payload = {"test": "payload"}
     config = Configuration(api_key=api_key)
+    notice = Notice(
+        error_class="TestError", error_message="Test message", config=config
+    )
 
     def test_request(request_object):
         assert request_object.get_header("X-api-key") == api_key
         assert request_object.get_full_url() == "{}/v1/notices/".format(config.endpoint)
-        assert request_object.data == b(json.dumps(payload))
+        assert request_object.data == b(json.dumps(notice.payload))
 
     with mock_urlopen(test_request) as request_mock:
-        send_notice(config, payload)
+        send_notice(config, notice)
 
 
 def test_connection_returns_notice_id():
     notice_id = str(uuid.uuid4())
     api_key = "badgerbadgermushroom"
-    payload = {"test": "payload", "error": {"token": notice_id}}
     config = Configuration(api_key=api_key)
+    notice = Notice(
+        error_class="TestError", error_message="Test message", config=config
+    )
 
     def test_payload(request_object):
-        assert request_object.data == b(json.dumps(payload))
+        assert request_object.data == b(json.dumps(notice.payload))
 
     with mock_urlopen(test_payload) as request_mock:
-        assert send_notice(config, payload) == notice_id
+        assert send_notice(config, notice) == notice.notice_id
 
 
 # TODO: figure out how to test logging output

--- a/honeybadger/tests/test_connection.py
+++ b/honeybadger/tests/test_connection.py
@@ -27,7 +27,6 @@ def test_connection_success():
 
 
 def test_connection_returns_notice_id():
-    notice_id = str(uuid.uuid4())
     api_key = "badgerbadgermushroom"
     config = Configuration(api_key=api_key)
     notice = Notice(
@@ -38,7 +37,9 @@ def test_connection_returns_notice_id():
         assert request_object.data == b(json.dumps(notice.payload))
 
     with mock_urlopen(test_payload) as request_mock:
-        assert send_notice(config, notice) == notice.notice_id
+        assert send_notice(config, notice) == notice.payload.get("error", {}).get(
+            "token", None
+        )
 
 
 # TODO: figure out how to test logging output

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -260,56 +260,6 @@ def test_event_without_event_type():
     assert payload["email"] == "user@example.com"
 
 
-def test_notify_with_tags():
-    def test_payload(request):
-        payload = json.loads(request.data.decode("utf-8"))
-        assert sorted(payload["error"]["tags"]) == sorted(["tag1"])
-
-    hb = Honeybadger()
-
-    with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key="aaa", force_report_data=True)
-        hb.notify(
-            error_class="Exception",
-            error_message="Test.",
-            context=dict(bar="foo"),
-            tags="tag1",
-        )
-
-
-def test_notify_with_context_tags():
-    def test_payload(request):
-        payload = json.loads(request.data.decode("utf-8"))
-        assert sorted(payload["error"]["tags"]) == sorted(["tag1"])
-
-    hb = Honeybadger()
-
-    with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key="aaa", force_report_data=True)
-        hb.set_context(_tags="tag1")
-        hb.notify(
-            error_class="Exception", error_message="Test.", context=dict(bar="foo")
-        )
-
-
-def test_notify_with_context_merging_tags():
-    def test_payload(request):
-        payload = json.loads(request.data.decode("utf-8"))
-        assert sorted(payload["error"]["tags"]) == sorted(["tag1", "tag2"])
-
-    hb = Honeybadger()
-
-    with mock_urlopen(test_payload) as request_mock:
-        hb.configure(api_key="aaa", force_report_data=True)
-        hb.set_context(_tags="tag1")
-        hb.notify(
-            error_class="Exception",
-            error_message="Test.",
-            context=dict(bar="foo"),
-            tags="tag2",
-        )
-
-
 def test_notify_with_before_notify_changes():
     def before_notify(notice):
         notice.payload["error"]["tags"] = ["tag1-updated"]

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -114,6 +114,25 @@ def test_notify_fake_connection_non_dev_environment():
             assert connection.call_count == 1
 
 
+def test_before_notify_with_none_return_value():
+    def before_notify(notice):
+        return None
+
+    hb = Honeybadger()
+    hb.configure(api_key="aaa", environment="development", before_notify=before_notify)
+    with patch(
+        "honeybadger.fake_connection.send_notice",
+        side_effect=MagicMock(return_value=True),
+    ) as fake_connection:
+        hb.notify(
+            error_class="Exception",
+            error_message="Test message.",
+            context={"foo": "bar"},
+        )
+
+        assert fake_connection.call_count == 0
+
+
 def test_notify_with_custom_params():
     def test_payload(request):
         payload = json.loads(request.data.decode("utf-8"))
@@ -288,4 +307,25 @@ def test_notify_with_context_merging_tags():
             error_message="Test.",
             context=dict(bar="foo"),
             tags="tag2",
+        )
+
+
+def test_notify_with_before_notify_changes():
+    def before_notify(notice):
+        notice.payload["error"]["tags"] = ["tag1-updated"]
+        return notice
+
+    def test_payload(request):
+        payload = json.loads(request.data.decode("utf-8"))
+        assert sorted(payload["error"]["tags"]) == sorted(["tag1-updated"])
+
+    hb = Honeybadger()
+
+    with mock_urlopen(test_payload) as request_mock:
+        hb.configure(api_key="aaa", force_report_data=True, before_notify=before_notify)
+        hb.notify(
+            error_class="Exception",
+            error_message="Test.",
+            context=dict(bar="foo"),
+            tags="tag1",
         )

--- a/honeybadger/tests/test_fake_connection.py
+++ b/honeybadger/tests/test_fake_connection.py
@@ -1,25 +1,24 @@
 from honeybadger.fake_connection import send_notice
+from honeybadger.config import Configuration
+from honeybadger.notice import Notice
 
 from testfixtures import log_capture  # type: ignore
 import json
 
 
-@log_capture()
+@log_capture("honeybadger.fake_connection")
 def test_send_notice_logging(l):
-    config = {"api_key": "aaa"}
-    payload = {"test": "payload", "error": {"token": "1234"}}
+    config = Configuration(api_key="aaa")
+    notice = Notice(
+        error_class="TestError", error_message="Test message", config=config
+    )
 
-    send_notice(config, payload)
+    send_notice(config, notice)
 
     l.check(
         (
             "honeybadger.fake_connection",
             "INFO",
             "Development mode is enabled; this error will be reported if it occurs after you deploy your app.",
-        ),
-        (
-            "honeybadger.fake_connection",
-            "DEBUG",
-            "[send_notice] config used is {} with payload {}".format(config, payload),
         ),
     )

--- a/honeybadger/tests/test_notice.py
+++ b/honeybadger/tests/test_notice.py
@@ -3,6 +3,7 @@ import pytest
 from honeybadger.config import Configuration
 from honeybadger.notice import Notice
 
+
 def test_notice_initialization():
     # Test with exception
     exception = Exception("Test exception")
@@ -13,7 +14,10 @@ def test_notice_initialization():
 
     # Test with error_class and error_message
     notice = Notice(error_class="TestError", error_message="Test message")
-    assert notice.exception == { "error_class": "TestError", "error_message": "Test message" }
+    assert notice.exception == {
+        "error_class": "TestError",
+        "error_message": "Test message",
+    }
     assert notice.error_class == "TestError"
     assert notice.error_message == "Test message"
 
@@ -27,28 +31,26 @@ def test_notice_initialization():
     assert notice.exception == exception
     assert notice.context["error_message"] == "Test message"
 
+
 def test_notice_excluded_exception():
-    config = Configuration(excluded_exceptions = ["TestError", "Exception"])
+    config = Configuration(excluded_exceptions=["TestError", "Exception"])
 
     # Test with excluded exception
     notice = Notice(
-        error_class="TestError",
-        error_message="Test message",
-        config=config
+        error_class="TestError", error_message="Test message", config=config
     )
     assert notice.excluded_exception() is True
 
     # Test with non-excluded exception
     notice = Notice(
-        error_class="NonExcludedError",
-        error_message="Test message",
-        config=config
+        error_class="NonExcludedError", error_message="Test message", config=config
     )
     assert notice.excluded_exception() is False
 
     # Test with exception
     notice = Notice(exception=Exception("Test exception"), config=config)
     assert notice.excluded_exception() is True
+
 
 def test_notice_payload():
     config = Configuration()
@@ -60,7 +62,9 @@ def test_notice_payload():
     assert payload["error"]["message"] == "Test exception"
 
     # Test with error_class and error_message
-    notice = Notice(error_class="TestError", error_message="Test message", config=config)
+    notice = Notice(
+        error_class="TestError", error_message="Test message", config=config
+    )
     payload = notice.payload
     assert payload["error"]["class"] == "TestError"
     assert payload["error"]["message"] == "Test message"

--- a/honeybadger/tests/test_notice.py
+++ b/honeybadger/tests/test_notice.py
@@ -1,0 +1,59 @@
+import pytest
+
+from honeybadger.config import Configuration
+from honeybadger.notice import Notice
+
+def test_notice_initialization():
+    # Test with exception
+    notice = Notice(exception=Exception("Test exception"))
+    assert notice.exception is not None
+    assert notice.error_class is None
+    assert notice.error_message is None
+
+    # Test with error_class and error_message
+    notice = Notice(error_class="TestError", error_message="Test message")
+    assert notice.exception == { "error_class": "TestError", "error_message": "Test message" }
+    assert notice.error_class == "TestError"
+    assert notice.error_message == "Test message"
+
+    # Test with neither exception nor error_class
+    with pytest.raises(ValueError):
+        Notice()
+
+def test_notice_excluded_exception():
+    config = Configuration(excluded_exceptions = ["TestError", "Exception"])
+
+    # Test with excluded exception
+    notice = Notice(
+        error_class="TestError",
+        error_message="Test message",
+        config=config
+    )
+    assert notice.excluded_exception() is True
+
+    # Test with non-excluded exception
+    notice = Notice(
+        error_class="NonExcludedError",
+        error_message="Test message",
+        config=config
+    )
+    assert notice.excluded_exception() is False
+
+    # Test with exception
+    notice = Notice(exception=Exception("Test exception"), config=config)
+    assert notice.excluded_exception() is True
+
+def test_notice_payload():
+    config = Configuration()
+
+    # Test with exception
+    notice = Notice(exception=Exception("Test exception"), config=config)
+    payload = notice.payload
+    assert payload["error"]["class"] == "Exception"
+    assert payload["error"]["message"] == "Test exception"
+
+    # Test with error_class and error_message
+    notice = Notice(error_class="TestError", error_message="Test message", config=config)
+    payload = notice.payload
+    assert payload["error"]["class"] == "TestError"
+    assert payload["error"]["message"] == "Test message"

--- a/honeybadger/tests/test_notice.py
+++ b/honeybadger/tests/test_notice.py
@@ -5,8 +5,9 @@ from honeybadger.notice import Notice
 
 def test_notice_initialization():
     # Test with exception
-    notice = Notice(exception=Exception("Test exception"))
-    assert notice.exception is not None
+    exception = Exception("Test exception")
+    notice = Notice(exception=exception)
+    assert notice.exception == exception
     assert notice.error_class is None
     assert notice.error_message is None
 
@@ -19,6 +20,12 @@ def test_notice_initialization():
     # Test with neither exception nor error_class
     with pytest.raises(ValueError):
         Notice()
+
+    # Test with exception and error_message
+    exception = Exception("Test exception")
+    notice = Notice(exception=exception, error_message="Test message")
+    assert notice.exception == exception
+    assert notice.context["error_message"] == "Test message"
 
 def test_notice_excluded_exception():
     config = Configuration(excluded_exceptions = ["TestError", "Exception"])


### PR DESCRIPTION
The main goal of this PR was to add a `before_notify` hook as part of the configuration. This allows the library to be configured to intercept, inspect, and alter a error notice before it is sent off to Honeybadger.

To make this easier, a new `Notice` class has been added so that there is a single object that gets passed into the hook. ~~The payload is generate upon instantiation and can be later inspected or altered in the hook.~~

~~This preemptive generation isn't ideal because it's a little cumbersome to work with the notice payload. However, the plugins implement the `generate_payload` method which takes in the formatted notice payload. After this, I'd like to take a stab at making it easier to manipulate a notice without having to dig into the final payload.~~

The payload is a cached property allowing the `before_notify` hook to alter the payload before sending.

The `before_notify` hook must return the notice in order for the notice to be sent. A `None` value will halt the sending. 

Closes: https://github.com/honeybadger-io/honeybadger-python/issues/187 and https://github.com/honeybadger-io/honeybadger-python/issues/185