### PR TITLE
feat: no longer raise exception in notice class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fix: removes raising an exception in the `Notice` class.
 
 ## [0.23.0] - 2025-05-12
 - Add `before_notify` hook to allow modification of notice before sending (#203)
 - Allow tags to be passed explicitly (#202)
 - Add `EventsWorker` for batching Insights events (#201)
+- Breaking: raises an exception if neither an `exception` nor an `error_class` is passed to `honeybadger.notify()`
 
 ## [0.22.1] - 2025-04-22
 - Fix: Prevent infinite loop in exception cause chains by capping traversal

--- a/honeybadger/tests/test_notice.py
+++ b/honeybadger/tests/test_notice.py
@@ -5,7 +5,7 @@ from honeybadger.config import Configuration
 from honeybadger.notice import Notice
 
 
-def test_notice_initialization():
+def test_notice_initialization_with_exception():
     # Test with exception
     exception = Exception("Test exception")
     notice = Notice(exception=exception)
@@ -13,6 +13,8 @@ def test_notice_initialization():
     assert notice.error_class is None
     assert notice.error_message is None
 
+
+def test_notice_initialization_with_error_class_and_error_message():
     # Test with error_class and error_message
     notice = Notice(error_class="TestError", error_message="Test message")
     assert notice.exception == {
@@ -22,10 +24,8 @@ def test_notice_initialization():
     assert notice.error_class == "TestError"
     assert notice.error_message == "Test message"
 
-    # Test with neither exception nor error_class
-    with pytest.raises(ValueError):
-        Notice()
 
+def test_notice_initialization_with_exception_and_error_message():
     # Test with exception and error_message
     exception = Exception("Test exception")
     notice = Notice(exception=exception, error_message="Test message")


### PR DESCRIPTION
This removes the exception raised in the Notice class and fixes the logic for assigning the hash to the exception attribute when an an exception is not present.

Also took the liberty to cleanup the initialization of the class to be a bit clearer.