### PR TITLE
fix(insights): fix result in fake_connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Fix: removes raising an exception in the `Notice` class.
+- Fix: `fake_connection` returns same type as `connection` (#212)
 
 ## [0.23.0] - 2025-05-12
 - Add `before_notify` hook to allow modification of notice before sending (#203)

--- a/honeybadger/fake_connection.py
+++ b/honeybadger/fake_connection.py
@@ -1,4 +1,5 @@
 import logging
+from .types import EventsSendResult, EventsSendStatus
 
 logger = logging.getLogger(__name__)
 
@@ -12,11 +13,11 @@ def send_notice(config, notice):
     return notice_id
 
 
-def send_events(config, payload):
+def send_events(config, payload) -> EventsSendResult:
     logger.info(
         "Development mode is enabled; this event will be reported if it occurs after you deploy your app."
     )
     logger.debug(
         "[send_events] config used is {} with payload {}".format(config, payload)
     )
-    return True
+    return EventsSendResult(EventsSendStatus.OK)


### PR DESCRIPTION
This updates the fake_connection to return the same type result as the connection, which will fix issues with the events_worker expecting the correct type in dev.