### PR TITLE
feat(insights): before_event callback

### DIFF
--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -22,6 +22,7 @@ class Configuration(object):
         # Insights options
         ("insights_enabled", bool),
         # Events options
+        ("before_event", callable),
         ("events_batch_size", int),
         ("events_max_queue_size", int),
         ("events_timeout", float),
@@ -48,6 +49,7 @@ class Configuration(object):
         self.before_notify = lambda notice: notice
 
         self.insights_enabled = False
+        self.before_event = lambda event: event
 
         self.events_max_batch_retries = 3
         self.events_max_queue_size = 10_000

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -107,6 +107,17 @@ class Honeybadger(object):
                 "The first argument must be either a string or a dictionary"
             )
 
+        if callable(self.config.before_event):
+            try:
+                next_payload = self.config.before_event(payload)
+                if next_payload is False:
+                    return  # Skip sending the event
+                elif next_payload is not payload and next_payload is not None:
+                    payload = next_payload  # Overwrite payload
+                # else: assume in-place mutation; keep payload as-is
+            except Exception as e:
+                logger.error("Error in before_event callback: %s", e)
+
         # Add a timestamp to the payload if not provided
         if "ts" not in payload:
             payload["ts"] = datetime.datetime.now(datetime.timezone.utc)

--- a/honeybadger/tests/contrib/test_asgi.py
+++ b/honeybadger/tests/contrib/test_asgi.py
@@ -3,7 +3,9 @@ import unittest
 from async_asgi_testclient import TestClient  # type: ignore
 import aiounittest
 import mock
+from honeybadger import honeybadger
 from honeybadger import contrib
+from honeybadger.config import Configuration
 
 
 class SomeError(Exception):
@@ -79,14 +81,11 @@ class ASGIPluginTestCase(unittest.TestCase):
 
 
 class ASGIEventPayloadTestCase(unittest.TestCase):
-    def setUp(self):
-        # wrap your ASGI app in the plugin
-        app = contrib.ASGIHoneybadger(asgi_app(), api_key="abcd", insights_enabled=True)
-        self.client = TestClient(app)
-
     @aiounittest.async_test
     @mock.patch("honeybadger.contrib.asgi.honeybadger.event")
     async def test_success_event_payload(self, event):
+        app = contrib.ASGIHoneybadger(asgi_app(), api_key="abcd", insights_enabled=True)
+        self.client = TestClient(app)
         # even if there’s a query, url stays just the path
         await self.client.get("/hello?x=1")
         event.assert_called_once()
@@ -97,3 +96,4 @@ class ASGIEventPayloadTestCase(unittest.TestCase):
         self.assertEqual(payload["path"], "/hello")
         self.assertEqual(payload["status"], 200)
         self.assertIsInstance(payload["duration"], float)
+        honeybadger.config = Configuration()


### PR DESCRIPTION
Adds a `before_event` callback with a similar implementation as the `before_notice` with one small change: This only rejects an event with an explicit `False` return. If the result is `None`, which is typically no return, then we assume that the user is mutating the payload and use the one passed in. @roelbondoc, what do you think about this tweak?

* Also fix config bleeding issue with asgi test