### PR TITLE
feat(insights): event_context

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,6 +15,7 @@ psutil
 pylint
 pytest
 pytest-cov
+pytest-asyncio
 six
 testfixtures
 typing-extensions

--- a/honeybadger/connection.py
+++ b/honeybadger/connection.py
@@ -3,7 +3,6 @@ import json
 import threading
 
 from urllib.error import HTTPError, URLError
-from typing import Protocol
 from six.moves.urllib import request
 from six import b
 

--- a/honeybadger/context_store.py
+++ b/honeybadger/context_store.py
@@ -1,0 +1,47 @@
+from contextvars import ContextVar
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+
+
+class ContextStore:
+    def __init__(self, name: str):
+        self._ctx: ContextVar[Optional[Dict[str, Any]]] = ContextVar(name, default=None)
+
+    def get(self) -> Dict[str, Any]:
+        data = self._ctx.get()
+        return {} if data is None else data.copy()
+
+    def clear(self) -> None:
+        self._ctx.set({})
+
+    def update(self, ctx: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        """
+        Merge into the current context. Accepts either:
+          - update({'foo': 'bar'})
+          - update(foo='bar', baz=123)
+          - or both: update({'foo': 'bar'}, baz=123)
+        """
+        to_merge: Dict[str, Any] = {}
+        if ctx:
+            to_merge.update(ctx)
+        to_merge.update(kwargs)
+
+        new = self.get()
+        new.update(to_merge)
+        self._ctx.set(new)
+
+    @contextmanager
+    def override(self, ctx: Optional[Dict[str, Any]] = None, **kwargs: Any):
+        """
+        Temporarily merge these into context for the duration of the with-block.
+        """
+        to_merge: Dict[str, Any] = {}
+        if ctx:
+            to_merge.update(ctx)
+        to_merge.update(kwargs)
+
+        token = self._ctx.set({**self.get(), **to_merge})
+        try:
+            yield
+        finally:
+            self._ctx.reset(token)

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -60,10 +60,7 @@ class Honeybadger(object):
         sys.excepthook = self.exception_hook
 
     def exception_hook(self, type, exception, exc_traceback):
-        notice = Notice(
-            exception=exception, thread_local=self.thread_local, config=self.config
-        )
-        self._send_notice(notice)
+        self.notify(exception=exception)
         self.existing_except_hook(type, exception, exc_traceback)
 
     def shutdown(self):

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -159,8 +159,8 @@ class Honeybadger(object):
     def _get_event_context(self):
         return event_context.get()
 
-    def set_event_context(self, **kwargs):
-        event_context.update(**kwargs)
+    def set_event_context(self, ctx: Optional[Dict[str, Any]] = None, **kwargs):
+        event_context.update(ctx, **kwargs)
 
     def reset_event_context(self):
         event_context.clear()

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -2,10 +2,9 @@ import threading
 from contextlib import contextmanager
 import sys
 import logging
-import copy
-import time
 import datetime
 import atexit
+from typing import Optional, Dict, Any, List
 
 from honeybadger.plugins import default_plugin_manager
 import honeybadger.connection as connection
@@ -13,18 +12,23 @@ import honeybadger.fake_connection as fake_connection
 from .events_worker import EventsWorker
 from .config import Configuration
 from .notice import Notice
+from .context_store import ContextStore
 
 logger = logging.getLogger("honeybadger")
 logger.addHandler(logging.NullHandler())
+
+error_context = ContextStore("honeybadger_error_context")
+event_context = ContextStore("honeybadger_event_context")
 
 
 class Honeybadger(object):
     TS_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     def __init__(self):
+        error_context.clear()
+        event_context.clear()
+
         self.config = Configuration()
-        self.thread_local = threading.local()
-        self.thread_local.context = {}
         self.events_worker = EventsWorker(
             self._connection(), self.config, logger=logging.getLogger("honeybadger")
         )
@@ -47,11 +51,9 @@ class Honeybadger(object):
 
         self._connection().send_notice(self.config, notice)
 
-    def _get_context(self):
-        return getattr(self.thread_local, "context", {})
-
-    def begin_request(self, request):
-        self.thread_local.context = self._get_context()
+    def begin_request(self, _):
+        error_context.clear()
+        event_context.clear()
 
     def wrap_excepthook(self, func):
         self.existing_except_hook = func
@@ -72,18 +74,22 @@ class Honeybadger(object):
         exception=None,
         error_class=None,
         error_message=None,
-        context={},
+        context: Optional[Dict[str, Any]] = None,
         fingerprint=None,
-        tags=[],
+        tags: Optional[List[str]] = None,
     ):
+        base = error_context.get()
+        tag_ctx = base.pop("_tags", [])
+        merged_ctx = {**base, **(context or {})}
+        merged_tags = list({*tag_ctx, *(tags or [])})
+
         notice = Notice(
             exception=exception,
             error_class=error_class,
             error_message=error_message,
-            context=context,
+            context=merged_ctx,
             fingerprint=fingerprint,
-            tags=tags,
-            thread_local=self.thread_local,
+            tags=merged_tags,
             config=self.config,
         )
         return self._send_notice(notice)
@@ -130,28 +136,29 @@ class Honeybadger(object):
         if self.config.is_aws_lambda_environment:
             default_plugin_manager.register(contrib.AWSLambdaPlugin())
 
-    def set_context(self, ctx=None, **kwargs):
-        # This operation is an update, not a set!
-        if not ctx:
-            ctx = kwargs
-        else:
-            ctx.update(kwargs)
-        self.thread_local.context = self._get_context()
-        self.thread_local.context.update(ctx)
+    # Error context
+    #
+    def _get_context(self):
+        return error_context.get()
+
+    def set_context(self, ctx: Optional[Dict[str, Any]] = None, **kwargs):
+        error_context.update(ctx, **kwargs)
 
     def reset_context(self):
-        self.thread_local.context = {}
+        error_context.clear()
 
     @contextmanager
-    def context(self, **kwargs):
-        original_context = copy.copy(self._get_context())
-        self.set_context(**kwargs)
-        try:
+    def context(self, ctx: Optional[Dict[str, Any]] = None, **kwargs):
+        with error_context.override(ctx, **kwargs):
             yield
-        except:
-            raise
-        else:
-            self.thread_local.context = original_context
+
+    # Event context
+    #
+    def _get_event_context(self):
+        return event_context.get()
+
+    def set_event_context(self, **kwargs):
+        event_context.update(**kwargs)
 
     def _connection(self):
         if self.config.is_dev() and not self.config.force_report_data:

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -119,7 +119,9 @@ class Honeybadger(object):
         if isinstance(payload["ts"], datetime.datetime):
             payload["ts"] = payload["ts"].strftime(self.TS_FORMAT)
 
-        return self.events_worker.push(payload)
+        final_payload = {**self._get_event_context(), **payload}
+
+        return self.events_worker.push(final_payload)
 
     def configure(self, **kwargs):
         self.config.set_config_from_dict(kwargs)
@@ -159,6 +161,14 @@ class Honeybadger(object):
 
     def set_event_context(self, **kwargs):
         event_context.update(**kwargs)
+
+    def reset_event_context(self):
+        event_context.clear()
+
+    @contextmanager
+    def event_context(self, ctx: Optional[Dict[str, Any]] = None, **kwargs):
+        with event_context.override(ctx, **kwargs):
+            yield
 
     def _connection(self):
         if self.config.is_dev() and not self.config.force_report_data:

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -49,11 +49,6 @@ class Notice(object):
                 return True
         return False
 
-    def _get_thread_context(self):
-        if self.thread_local is None:
-            return {}
-        return getattr(self.thread_local, "context", {})
-
     def _construct_tags(self, tags):
         """
         Accepts either:

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -9,14 +9,11 @@ class Notice(object):
         self.error_message = kwargs.get("error_message", None)
         self.exc_traceback = kwargs.get("exc_traceback", None)
         self.fingerprint = kwargs.get("fingerprint", None)
-        self.thread_local = kwargs.get("thread_local", None)
         self.config = kwargs.get("config", None)
         self.context = kwargs.get("context", {})
         self.tags = self._construct_tags(kwargs.get("tags", []))
 
         self._process_exception()
-        self._process_context()
-        self._process_tags()
 
     def _process_exception(self):
         if self.exception is None and self.error_class:
@@ -27,15 +24,6 @@ class Notice(object):
                 self.exception.update({"error_message": self.error_message})
         elif self.exception and self.error_message:
             self.context["error_message"] = self.error_message
-
-    def _process_context(self):
-        self.context = dict(**self._get_thread_context(), **self.context)
-
-    def _process_tags(self):
-        tags_from_context = self._construct_tags(
-            self._get_thread_context().get("_tags", [])
-        )
-        self.tags = list(set(tags_from_context + self.tags))
 
     @cached_property
     def payload(self):
@@ -67,9 +55,23 @@ class Notice(object):
         return getattr(self.thread_local, "context", {})
 
     def _construct_tags(self, tags):
-        constructed_tags = []
+        """
+        Accepts either:
+          - a single string (possibly comma-separated)
+          - a list of strings (each possibly comma-separated)
+        and returns a flat list of stripped tags.
+        """
+        raw = []
         if isinstance(tags, str):
-            constructed_tags = [tag.strip() for tag in tags.split(",")]
-        elif isinstance(tags, list):
-            constructed_tags = tags
-        return constructed_tags
+            raw = [tags]
+        elif isinstance(tags, (list, tuple)):
+            raw = tags
+        out = []
+        for item in raw:
+            if not isinstance(item, str):
+                continue
+            for part in item.split(","):
+                t = part.strip()
+                if t:
+                    out.append(t)
+        return out

--- a/honeybadger/protocols.py
+++ b/honeybadger/protocols.py
@@ -1,9 +1,9 @@
-from typing import Protocol, Dict, Any, Optional, List
+from typing import Protocol, Any, Optional, List
 from .types import EventsSendResult, Notice, Event
 
 
 class Connection(Protocol):
-    def send_notice(self, config: Any, payload: Notice) -> Optional[str]:
+    def send_notice(self, config: Any, notice: Notice) -> Optional[str]:
         """
         Send an error notice to Honeybadger.
 

--- a/honeybadger/tests/contrib/test_asgi.py
+++ b/honeybadger/tests/contrib/test_asgi.py
@@ -3,7 +3,9 @@ import unittest
 from async_asgi_testclient import TestClient  # type: ignore
 import aiounittest
 import mock
+from honeybadger import honeybadger
 from honeybadger import contrib
+from honeybadger.config import Configuration
 
 
 class SomeError(Exception):
@@ -79,14 +81,11 @@ class ASGIPluginTestCase(unittest.TestCase):
 
 
 class ASGIEventPayloadTestCase(unittest.TestCase):
-    def setUp(self):
-        # wrap your ASGI app in the plugin
-        app = contrib.ASGIHoneybadger(asgi_app(), api_key="abcd", insights_enabled=True)
-        self.client = TestClient(app)
-
     @aiounittest.async_test
     @mock.patch("honeybadger.contrib.asgi.honeybadger.event")
     async def test_success_event_payload(self, event):
+        app = contrib.ASGIHoneybadger(asgi_app(), api_key="abcd", insights_enabled=True)
+        self.client = TestClient(app)
         # even if there’s a query, url stays just the path
         await self.client.get("/hello?x=1")
         event.assert_called_once()
@@ -97,3 +96,4 @@ class ASGIEventPayloadTestCase(unittest.TestCase):
         self.assertEqual(payload["path"], "/hello")
         self.assertEqual(payload["status"], 200)
         self.assertIsInstance(payload["duration"], float)
+        honeybadger.config = Configuration()

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -100,6 +100,27 @@ def test_notify_merges_context_and_tags(monkeypatch):
     assert set(captured["tags"]) == {"from_ctx", "another_tag", "explicit"}
 
 
+def test_exception_hook_calls_notify(monkeypatch):
+    hb = Honeybadger()
+    captured = {}
+
+    def fake_send(notice=None, **kwargs):
+        captured["notified"] = notice
+        return "sent"
+
+    def fake_existing_except_hook(*args, **kwargs):
+        captured["hook"] = True
+
+    monkeypatch.setattr(hb, "_send_notice", fake_send)
+
+    exc = ValueError("fail!")
+    hb.wrap_excepthook(fake_existing_except_hook)
+    hb.exception_hook(ValueError, exc, None)
+
+    assert captured["notified"].exception == exc
+    assert captured["hook"] is True
+
+
 def test_threading():
     hb = Honeybadger()
     hb.configure(api_key="aaa", environment="development")  # Explicitly use development

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -318,6 +318,37 @@ def test_event_without_event_type():
     assert payload["email"] == "user@example.com"
 
 
+def test_event_with_event_context():
+    mock_events_worker = MagicMock()
+
+    hb = Honeybadger()
+    hb.events_worker = mock_events_worker
+    hb.configure(api_key="aaa", force_report_data=True)
+    hb.set_event_context(service="web")
+    hb.event(event_type="order.completed", data=dict(email="user@example.com"))
+
+    mock_events_worker.push.assert_called_once()
+    payload = mock_events_worker.push.call_args[0][0]
+
+    assert payload["service"] == "web"
+    assert payload["email"] == "user@example.com"
+
+
+def test_event_with_event_context_does_not_override():
+    mock_events_worker = MagicMock()
+
+    hb = Honeybadger()
+    hb.events_worker = mock_events_worker
+    hb.configure(api_key="aaa", force_report_data=True)
+    hb.set_event_context(service="web")
+    hb.event(event_type="order.completed", data=dict(service="my-service!"))
+
+    mock_events_worker.push.assert_called_once()
+    payload = mock_events_worker.push.call_args[0][0]
+
+    assert payload["service"] == "my-service!"
+
+
 def test_notify_with_before_notify_changes():
     def before_notify(notice):
         notice.payload["error"]["tags"] = ["tag1-updated"]

--- a/honeybadger/tests/test_notice.py
+++ b/honeybadger/tests/test_notice.py
@@ -85,34 +85,16 @@ def test_notice_with_tags():
     assert "tag2" in payload["error"]["tags"]
 
 
-def test_notify_with_context_tags():
+def test_notice_with_multiple_tags():
     config = Configuration()
-    thread_local = threading.local()
-    thread_local.context = {"_tags": "tag1, tag2"}
 
     notice = Notice(
         error_class="TestError",
         error_message="Test message",
-        thread_local=thread_local,
+        tags=["tag1, tag2", "tag3"],
         config=config,
     )
     payload = notice.payload
     assert "tag1" in payload["error"]["tags"]
     assert "tag2" in payload["error"]["tags"]
-
-
-def test_notify_with_context_merging_tags():
-    config = Configuration()
-    thread_local = threading.local()
-    thread_local.context = {"_tags": "tag1"}
-
-    notice = Notice(
-        error_class="TestError",
-        error_message="Test message",
-        thread_local=thread_local,
-        tags="tag2",
-        config=config,
-    )
-    payload = notice.payload
-    assert "tag1" in payload["error"]["tags"]
-    assert "tag2" in payload["error"]["tags"]
+    assert "tag3" in payload["error"]["tags"]

--- a/honeybadger/types.py
+++ b/honeybadger/types.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from typing import Optional, Protocol, Any, Dict
+from typing import Optional, Any, Dict
 
 
 class EventsSendStatus(Enum):

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 testpaths = honeybadger/tests
 python_files = test_*.py
 addopts = --mypy
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
This adds a new set of functions to the `Honeybadger` class for setting and applying event context.

I also refactored the internals of storing context quite a bit:

* Replaced the threadlocals with a `ContextStore` class that uses `ContextVar`, which is the recommended way to manage thread local variables in a 3.7+ world.
* Used `ContextStore` to create both notice and event context stores
* Updated the core methods to delegate to the new instances
* I refactored the Notice class by removing the thread local code, opting to just send in the context & tag variable, keeping it just a pure rendering class.