### PR TITLE
fix: create dict for missing exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Fix: Always create error dictionary if exception is not provided (#222)
 
 ## [1.0.0] - 2025-06-05
 - Allow overriding development environments (#218)

--- a/honeybadger/notice.py
+++ b/honeybadger/notice.py
@@ -19,14 +19,14 @@ class Notice(object):
         self._process_tags()
 
     def _process_exception(self):
-        if self.exception is None and self.error_class:
+        if self.exception and self.error_message:
+            self.context["error_message"] = self.error_message
+
+        if self.exception is None:
             self.exception = {
                 "error_class": self.error_class,
+                "error_message": self.error_message,
             }
-            if self.error_message:
-                self.exception.update({"error_message": self.error_message})
-        elif self.exception and self.error_message:
-            self.context["error_message"] = self.error_message
 
     def _process_context(self):
         self.context = dict(**self._get_thread_context(), **self.context)

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -279,3 +279,20 @@ def test_notify_with_before_notify_changes():
             context=dict(bar="foo"),
             tags="tag1",
         )
+
+
+def test_notify_with_error_message_only():
+    """Test the case where only an error message is provided"""
+
+    def test_payload(request):
+        payload = json.loads(request.data.decode("utf-8"))
+        # This demonstrates the current bug - NoneType class and None message
+        assert payload["error"]["class"] == "dict"
+        assert payload["error"]["message"] == "Some error message"
+
+    hb = Honeybadger()
+
+    with mock_urlopen(test_payload):
+        hb.configure(api_key="aaa", force_report_data=True)
+        # This should fail according to breaking change, but currently creates malformed payload
+        hb.notify(error_message="Some error message", context={"foo": "bar"})


### PR DESCRIPTION
Partially fixes #221

This reverts back to the previous way we dealt with a missing exception.