### PR TITLE
fix: register signal handler only in main thread

### DIFF
--- a/honeybadger/__init__.py
+++ b/honeybadger/__init__.py
@@ -18,6 +18,7 @@ __all__ = ["honeybadger", "__version__"]
 honeybadger = Honeybadger()
 honeybadger.wrap_excepthook(sys.excepthook)
 
+
 def _register_signal_handler():
     orig = signal.getsignal(signal.SIGTERM)
 
@@ -29,6 +30,6 @@ def _register_signal_handler():
 
     signal.signal(signal.SIGTERM, _on_term)
 
+
 if threading.main_thread():
     _register_signal_handler()
-

--- a/honeybadger/__init__.py
+++ b/honeybadger/__init__.py
@@ -31,5 +31,5 @@ def _register_signal_handler():
     signal.signal(signal.SIGTERM, _on_term)
 
 
-if threading.main_thread():
+if threading.current_thread() is threading.main_thread():
     _register_signal_handler()


### PR DESCRIPTION
@joshuap reported that Python throws an error when trying to register the signal handler in any other thread than the main:
```
File "/Users/josh/tmp/django-monitoring/django-monitoring/.venv/lib/python3.12/site-packages/honeybadger/__init__.py", line 30, in <module>
    signal.signal(signal.SIGTERM, _on_term)
  File "/Users/josh/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/signal.py", line 58, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: signal only works in main thread of the main interpreter
```

Usually, Honeybadger's initialization code runs on the main thread, but it is possible for it to run in another thread, such as when running django in dev mode with auto-reload.
Here's how Claude explains the issue:

> Summary of the Signal Issue
> 
>   The Problem: Honeybadger's signal handler registration happens at import time in honeybadger/__init__.py:30:
>   signal.signal(signal.SIGTERM, _on_term)
> 
>   Why it fails with Django dev server:
>   1. Django's autoreloader runs in a separate thread (not main thread)
>   2. When the autoreloader imports modules (like honeybadger middleware), it triggers the signal registration
>   3. Python's signal.signal() can only be called from the main thread of the main interpreter
>   4. Result: ValueError: signal only works in main thread of the main interpreter
> 
>   What the signal handler does: It registers a graceful shutdown handler for SIGTERM so Honeybadger can flush pending error reports before the process terminates.
> 
>   Why it works in production: Production servers (gunicorn, uwsgi, etc.) don't use Django's autoreloader threading mechanism, so imports happen in the main thread.