### PR TITLE
chore: add concurrency control to GitHub workflows

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,9 @@
 name: Code Quality
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [ master ]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,9 @@
 name: Test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
This change will cancel in-progress CI workflows if new code is pushed. This helps saves Github CI minutes usage and CI run time, since you don't have to wait for previous, outdated workflows to complete.