### PR TITLE
fix: pass exc_traceback through exception_hook to payload

### DIFF
--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -7,6 +7,7 @@ import atexit
 import uuid
 import hashlib
 
+from types import TracebackType
 from typing import Optional, Dict, Any, List
 
 from honeybadger.plugins import default_plugin_manager
@@ -62,7 +63,12 @@ class Honeybadger(object):
         self.existing_except_hook = func
         sys.excepthook = self.exception_hook
 
-    def exception_hook(self, type, exception, exc_traceback):
+    def exception_hook(
+        self,
+        type: type[BaseException],
+        exception: BaseException,
+        exc_traceback: Optional[TracebackType],
+    ) -> None:
         self.notify(exception=exception, exc_traceback=exc_traceback)
         self.existing_except_hook(type, exception, exc_traceback)
 
@@ -77,7 +83,7 @@ class Honeybadger(object):
         context: Optional[Dict[str, Any]] = None,
         fingerprint=None,
         tags: Optional[List[str]] = None,
-        exc_traceback=None,
+        exc_traceback: Optional[TracebackType] = None,
     ):
         base = error_context.get()
         tag_ctx = base.pop("_tags", [])

--- a/honeybadger/core.py
+++ b/honeybadger/core.py
@@ -63,7 +63,7 @@ class Honeybadger(object):
         sys.excepthook = self.exception_hook
 
     def exception_hook(self, type, exception, exc_traceback):
-        self.notify(exception=exception)
+        self.notify(exception=exception, exc_traceback=exc_traceback)
         self.existing_except_hook(type, exception, exc_traceback)
 
     def shutdown(self):
@@ -77,6 +77,7 @@ class Honeybadger(object):
         context: Optional[Dict[str, Any]] = None,
         fingerprint=None,
         tags: Optional[List[str]] = None,
+        exc_traceback=None,
     ):
         base = error_context.get()
         tag_ctx = base.pop("_tags", [])
@@ -89,6 +90,7 @@ class Honeybadger(object):
             exception=exception,
             error_class=error_class,
             error_message=error_message,
+            exc_traceback=exc_traceback,
             context=merged_ctx,
             fingerprint=fingerprint,
             tags=merged_tags,

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -174,7 +174,7 @@ def create_payload(
     if exc_traceback is None:
         exc_traceback = sys.exc_info()[2]
 
-    if exc_traceback is None and hasattr(exception, '__traceback__'):
+    if exc_traceback is None and isinstance(exception, BaseException):
         exc_traceback = exception.__traceback__
 
     # if context is None, Initialize as an emptty dict

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -177,7 +177,7 @@ def create_payload(
     if exc_traceback is None and isinstance(exception, BaseException):
         exc_traceback = exception.__traceback__
 
-    # if context is None, Initialize as an emptty dict
+    # if context is None, Initialize as an empty dict
     if not context:
         context = {}
 

--- a/honeybadger/payload.py
+++ b/honeybadger/payload.py
@@ -174,6 +174,9 @@ def create_payload(
     if exc_traceback is None:
         exc_traceback = sys.exc_info()[2]
 
+    if exc_traceback is None and hasattr(exception, '__traceback__'):
+        exc_traceback = exception.__traceback__
+
     # if context is None, Initialize as an emptty dict
     if not context:
         context = {}

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -132,15 +132,19 @@ def test_exception_hook_passes_traceback(monkeypatch):
     def fake_existing_except_hook(*args, **kwargs):
         pass
 
+    import sys
+
     monkeypatch.setattr(hb, "_send_notice", fake_send)
+    original_hook = sys.excepthook
     hb.wrap_excepthook(fake_existing_except_hook)
 
     try:
         raise ValueError("traceback test")
     except ValueError:
-        import sys
         t, v, tb = sys.exc_info()
         hb.exception_hook(t, v, tb)
+    finally:
+        sys.excepthook = original_hook
 
     notice = captured["notified"]
     assert notice.exc_traceback is not None

--- a/honeybadger/tests/test_core.py
+++ b/honeybadger/tests/test_core.py
@@ -121,6 +121,32 @@ def test_exception_hook_calls_notify(monkeypatch):
     assert captured["hook"] is True
 
 
+def test_exception_hook_passes_traceback(monkeypatch):
+    hb = Honeybadger()
+    captured = {}
+
+    def fake_send(notice=None, **kwargs):
+        captured["notified"] = notice
+        return "sent"
+
+    def fake_existing_except_hook(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(hb, "_send_notice", fake_send)
+    hb.wrap_excepthook(fake_existing_except_hook)
+
+    try:
+        raise ValueError("traceback test")
+    except ValueError:
+        import sys
+        t, v, tb = sys.exc_info()
+        hb.exception_hook(t, v, tb)
+
+    notice = captured["notified"]
+    assert notice.exc_traceback is not None
+    assert notice.exc_traceback is tb
+
+
 def test_threading():
     hb = Honeybadger()
     hb.configure(api_key="aaa", environment="development")  # Explicitly use development

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -247,3 +247,19 @@ def test_create_payload_with_correlation_context():
         exception, config=config, correlation_context={"request_id": request_id}
     )
     assert payload["correlation_context"]["request_id"] == request_id
+
+
+def test_create_payload_falls_back_to_exception_traceback():
+    config = Configuration()
+
+    try:
+        raise ValueError("traceback fallback test")
+    except ValueError as e:
+        exc = e
+
+    # Outside except block: sys.exc_info() is empty, exc_traceback is None,
+    # so create_payload should fall back to exc.__traceback__.
+    payload = create_payload(exc, exc_traceback=None, config=config)
+    backtrace = payload["error"]["backtrace"]
+    assert len(backtrace) > 0
+    assert any("test_payload" in frame["file"] for frame in backtrace)

--- a/honeybadger/tests/test_payload.py
+++ b/honeybadger/tests/test_payload.py
@@ -252,10 +252,11 @@ def test_create_payload_with_correlation_context():
 def test_create_payload_falls_back_to_exception_traceback():
     config = Configuration()
 
+    exc = ValueError("traceback fallback test")
     try:
-        raise ValueError("traceback fallback test")
-    except ValueError as e:
-        exc = e
+        raise exc
+    except ValueError:
+        pass
 
     # Outside except block: sys.exc_info() is empty, exc_traceback is None,
     # so create_payload should fall back to exc.__traceback__.


### PR DESCRIPTION
## Summary
- `exception_hook` received `exc_traceback` from `sys.excepthook` but dropped it when calling `notify()`, causing payload generation to use `traceback.extract_stack()` (the honeybadger internals' call stack) instead of the actual exception traceback
- This incorrect fallback path could produce an `IndexError: list index out of range` on Python 3.14 depending on stack composition
- Adds `exception.__traceback__` as a defense-in-depth fallback in `create_payload` for cases where both the explicit parameter and `sys.exc_info()[2]` are None

## Test plan
- [x] Added `test_exception_hook_passes_traceback` verifying traceback flows through `exception_hook` → `notify` → `Notice`
- [x] All 110 non-contrib tests pass on Python 3.14.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)