### PR TITLE
feat: add support for Oban

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,43 @@ app.conf.update(
 CeleryHoneybadger(app, report_exceptions=True)
 ```
 
+### Oban
+
+Honeybadger integrates with [Oban](https://github.com/oban-bg/oban-py) to report unhandled worker exceptions and emit per-job telemetry to Honeybadger Insights.
+
+Requires Python 3.12+ and `oban>=0.6.2`.
+
+```python
+from oban import Oban
+from honeybadger import honeybadger
+from honeybadger.contrib.oban import ObanHoneybadger
+
+honeybadger.configure(api_key="...", insights_enabled=True)
+ObanHoneybadger(report_exceptions=True).init()
+
+async with Oban(pool=pool, queues={"default": 10}) as oban:
+    ...
+```
+
+`report_exceptions=True` installs an `executor.wrap_result` extension that calls `honeybadger.notify` whenever a worker raises. When `insights_enabled=True`, the integration also emits `oban.job_finished` events (and `oban.<loop>_exception` events for maintenance-loop failures).
+
+Configuration:
+
+```python
+honeybadger.configure(insights_config={
+    "oban": {
+        "exclude_workers": ["myapp.NoisyWorker"],
+        "include_args": True,  # include job.args / job.meta in Insights events (default: False)
+    }
+})
+```
+
+`exclude_workers` filters Insights events only — error reporting is unaffected.
+
+Honeybadger event context set before enqueueing a job is automatically propagated through `job.meta` so the Insights timeline can link the enqueuing request to the worker's execution.
+
+Only one `ObanHoneybadger` instance may be active per process. Call `tearDown()` to fully reverse all wiring (useful in tests or for application shutdown hooks).
+
 ### Other frameworks / plain Python app
 
 Django and Flask are the only explicitly supported frameworks at the moment. For other frameworks (tornado, web2py, etc.) or a plain Python script, simply import honeybadger and configure it with your API key. Honeybadger uses a global exception hook to automatically report any uncaught exceptions.
@@ -296,6 +333,7 @@ automatically instrument the following libraries:
 - Flask requests & database queries
 - ASGI requests
 - Celery tasks
+- Oban workers & maintenance loops
 
 ### Configuration
 
@@ -370,6 +408,27 @@ The following instrumentation configs are available:
         }
     )
 ```
+
+#### Oban
+
+Configure per-integration options for Oban. All fields are optional.
+
+```python
+    honeybadger.configure(
+        insights_config={
+            "oban": {
+                # Disable instrumentation for Oban, defaults to False
+                "disabled": False,
+                # Exact strings or compiled regex patterns to exclude, defaults to []
+                "exclude_workers": ["myapp.NoisyWorker"],
+                # Include job.args / job.meta in Insights events, defaults to False
+                "include_args": False,
+            }
+        }
+    )
+```
+
+`exclude_workers` patterns match against the worker's fully-qualified class name. String patterns are exact-match; compiled regex patterns use `.search()`. `exclude_workers` filters Insights events only — error reporting is unaffected.
 
 #### DB
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,3 +30,4 @@ celery-types
 
 # For Python 3.10+ which removed cgi module
 legacy-cgi==2.6.4
+oban==0.6.2; python_version >= "3.12"

--- a/examples/oban_app/README.md
+++ b/examples/oban_app/README.md
@@ -1,0 +1,67 @@
+# Oban contrib demo
+
+A self-contained sample that exercises `honeybadger.contrib.oban` end-to-end:
+error reporting via the `executor.wrap_result` extension, per-job Insights
+events, maintenance-loop events, and event-context propagation from enqueuer
+to worker.
+
+Requires Python ≥ 3.12 (the `oban` package's own constraint) and a running
+PostgreSQL. A `docker-compose.yml` is included for a one-command Postgres on
+port 5439 so it won't clash with any host instance.
+
+## Setup
+
+```sh
+cd examples/oban_app
+
+# 1. Bring up Postgres (non-default port 5439).
+docker compose up -d
+
+# 2. Create a Python 3.12 venv and install deps. From inside this directory:
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -e ../..        # the in-repo honeybadger build
+pip install -r requirements.txt
+
+# 3. Install the Oban schema (one-time per database).
+python -m oban install --dsn "postgresql://oban:oban@localhost:5439/oban_demo"
+```
+
+## Run
+
+```sh
+python app.py
+```
+
+This will:
+
+1. Configure Honeybadger (API key inlined as a demo; override with
+   `HONEYBADGER_API_KEY`) with `insights_enabled=True`.
+2. Init `ObanHoneybadger(report_exceptions=True)`.
+3. Start Oban with a `default` and `reports` queue.
+4. Enqueue a mix of:
+   - A successful `SendEmailWorker` job (no event context).
+   - A failing `FlakyWorker` job that always raises (exercises error
+     reporting through `executor.wrap_result`).
+   - A `@job`-decorated `generate_report` function.
+5. Re-enqueue the same set with a Honeybadger event context set, so the
+   propagation path lights up.
+6. Sleep ~15s while Oban processes everything, then shut down cleanly.
+
+Watch the console: you'll see worker output, Honeybadger's debug logs about
+event batches being sent, and any 4xx/5xx responses from the API. In your
+Honeybadger project you should see:
+
+- An `oban.job_finished` event per job with `worker`, `queue`, `state`,
+  `duration`, `queue_time`, `attempt`, `max_attempts`, `tags`, and (for
+  failures) `error_type` / `error_message`.
+- Events emitted during the second batch carry `request_id` and `user_id`
+  from the propagated event context.
+- Error notices for each `FlakyWorker` run, enriched by `ObanPlugin` with
+  component, action, params, and job context.
+
+## Tear down
+
+```sh
+docker compose down -v   # also drop the volume
+```

--- a/examples/oban_app/README.md
+++ b/examples/oban_app/README.md
@@ -30,13 +30,16 @@ python -m oban install --dsn "postgresql://oban:oban@localhost:5439/oban_demo"
 ## Run
 
 ```sh
-python app.py
+HONEYBADGER_API_KEY=hbp_your_real_key_here python app.py
 ```
+
+The default in `app.py` is an obvious placeholder (`hbp_REPLACE_ME_WITH_YOUR_OWN_KEY`)
+and will fail to send to Honeybadger — set the env var to a real project key.
 
 This will:
 
-1. Configure Honeybadger (API key inlined as a demo; override with
-   `HONEYBADGER_API_KEY`) with `insights_enabled=True`.
+1. Configure Honeybadger (API key from `HONEYBADGER_API_KEY`) with
+   `insights_enabled=True`.
 2. Init `ObanHoneybadger(report_exceptions=True)`.
 3. Start Oban with a `default` and `reports` queue.
 4. Enqueue a mix of:

--- a/examples/oban_app/README.md
+++ b/examples/oban_app/README.md
@@ -33,9 +33,6 @@ python -m oban install --dsn "postgresql://oban:oban@localhost:5439/oban_demo"
 HONEYBADGER_API_KEY=hbp_your_real_key_here python app.py
 ```
 
-The default in `app.py` is an obvious placeholder (`hbp_REPLACE_ME_WITH_YOUR_OWN_KEY`)
-and will fail to send to Honeybadger — set the env var to a real project key.
-
 This will:
 
 1. Configure Honeybadger (API key from `HONEYBADGER_API_KEY`) with

--- a/examples/oban_app/app.py
+++ b/examples/oban_app/app.py
@@ -1,0 +1,121 @@
+"""Sample app exercising the honeybadger.contrib.oban integration.
+
+Setup (one-time):
+
+    1. Start Postgres (see docker-compose.yml in this directory):
+         docker compose up -d
+
+    2. Install the Oban schema:
+         python -m oban install --dsn "postgresql://oban:oban@localhost:5439/oban_demo"
+
+Run:
+
+    python app.py
+
+The script configures Honeybadger with Insights enabled, starts Oban with
+two queues, enqueues a mix of successful jobs, failing jobs, and @job
+function jobs (some with a Honeybadger event context set), then runs for
+~15 seconds while Oban processes them. You should see:
+
+  * `oban.job_finished` Insights events for each job
+  * `request_id` propagated into job execution and the resulting events
+  * Honeybadger error notices for the failing worker (with worker name,
+    args, queue, attempt, etc. enriched by ObanPlugin)
+"""
+
+import asyncio
+import logging
+import os
+import uuid
+
+from oban import Oban, job, worker
+
+from honeybadger import honeybadger
+from honeybadger.contrib.oban import ObanHoneybadger
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logging.getLogger("honeybadger").setLevel(logging.DEBUG)
+logging.getLogger("oban").setLevel(logging.INFO)
+
+# Demo Honeybadger project. Replace with your own to point telemetry elsewhere,
+# or set HONEYBADGER_API_KEY to override.
+API_KEY = os.environ.get("HONEYBADGER_API_KEY", "hbp_sNc9oqQlVDO0TVCngW7EBlVwHv2HIZ3bgllO")
+
+DSN = os.environ.get("OBAN_DSN", "postgresql://oban:oban@localhost:5439/oban_demo")
+
+
+@worker(queue="default", max_attempts=2)
+class SendEmailWorker:
+    async def process(self, job):
+        # Simulate doing the work.
+        await asyncio.sleep(0.1)
+        print(f"[SendEmailWorker] sent email to {job.args.get('to')}")
+        return None
+
+
+@worker(queue="default", max_attempts=2)
+class FlakyWorker:
+    """Always raises so we exercise the error-reporting path."""
+
+    async def process(self, job):
+        await asyncio.sleep(0.05)
+        raise ValueError(f"boom while processing {job.args!r}")
+
+
+@job(queue="reports")
+def generate_report(report_id: str):
+    print(f"[generate_report] generating report {report_id}")
+
+
+async def main():
+    # Configure Honeybadger BEFORE init() so the contrib reads the right flags.
+    honeybadger.configure(
+        api_key=API_KEY,
+        environment="oban-demo",
+        insights_enabled=True,
+        # Force sending in dev environments (otherwise Honeybadger drops payloads).
+        force_report_data=True,
+    )
+
+    # Wire up the contrib. report_exceptions=True installs the wrap_result
+    # extension that auto-reports unhandled worker exceptions.
+    ObanHoneybadger(report_exceptions=True).init()
+
+    pool = await Oban.create_pool(dsn=DSN)
+    try:
+        async with Oban(
+            pool=pool,
+            queues={"default": 5, "reports": 2},
+        ) as oban:
+            # Enqueue a few jobs WITHOUT any honeybadger event context set.
+            await SendEmailWorker.enqueue({"to": "anon@example.com", "subject": "Hi"})
+            await FlakyWorker.enqueue({"task": "first"})
+            await generate_report.enqueue("daily-001")
+
+            # Enqueue more jobs WITH a honeybadger event context, so the
+            # Insights timeline links request -> enqueue -> execution.
+            request_id = str(uuid.uuid4())
+            honeybadger.set_event_context({"request_id": request_id, "user_id": "user-42"})
+            try:
+                await SendEmailWorker.enqueue({"to": "you@example.com", "subject": "From request"})
+                await FlakyWorker.enqueue({"task": "in-request"})
+                await generate_report.enqueue("requested-007")
+                print(f"[enqueuer] enqueued with request_id={request_id}")
+            finally:
+                honeybadger.reset_event_context()
+
+            # Give Oban time to process everything and emit telemetry.
+            print("[runner] sleeping 15s while Oban processes jobs...")
+            await asyncio.sleep(15)
+            print("[runner] shutting down")
+    finally:
+        await pool.close()
+        # Drain pending Honeybadger events before exit.
+        try:
+            honeybadger.events_worker.stop()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/oban_app/app.py
+++ b/examples/oban_app/app.py
@@ -109,10 +109,7 @@ async def main():
     finally:
         await pool.close()
         # Drain pending Honeybadger events before exit.
-        try:
-            honeybadger.events_worker.stop()
-        except Exception:
-            pass
+        honeybadger.shutdown()
 
 
 if __name__ == "__main__":

--- a/examples/oban_app/app.py
+++ b/examples/oban_app/app.py
@@ -37,9 +37,9 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname
 logging.getLogger("honeybadger").setLevel(logging.DEBUG)
 logging.getLogger("oban").setLevel(logging.INFO)
 
-# Demo Honeybadger project. Replace with your own to point telemetry elsewhere,
-# or set HONEYBADGER_API_KEY to override.
-API_KEY = os.environ.get("HONEYBADGER_API_KEY", "hbp_sNc9oqQlVDO0TVCngW7EBlVwHv2HIZ3bgllO")
+# Set HONEYBADGER_API_KEY in your shell before running this script.
+# The fallback below is an obvious placeholder, not a real key.
+API_KEY = os.environ.get("HONEYBADGER_API_KEY", "hbp_REPLACE_ME_WITH_YOUR_OWN_KEY")
 
 DSN = os.environ.get("OBAN_DSN", "postgresql://oban:oban@localhost:5439/oban_demo")
 

--- a/examples/oban_app/app.py
+++ b/examples/oban_app/app.py
@@ -37,8 +37,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname
 logging.getLogger("honeybadger").setLevel(logging.DEBUG)
 logging.getLogger("oban").setLevel(logging.INFO)
 
-# Set HONEYBADGER_API_KEY in your shell before running this script.
-# The fallback below is an obvious placeholder, not a real key.
 API_KEY = os.environ.get("HONEYBADGER_API_KEY", "hbp_REPLACE_ME_WITH_YOUR_OWN_KEY")
 
 DSN = os.environ.get("OBAN_DSN", "postgresql://oban:oban@localhost:5439/oban_demo")

--- a/examples/oban_app/docker-compose.yml
+++ b/examples/oban_app/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:18
+    container_name: oban-demo-postgres
+    environment:
+      POSTGRES_USER: oban
+      POSTGRES_PASSWORD: oban
+      POSTGRES_DB: oban_demo
+    ports:
+      - "5439:5432"
+    volumes:
+      - oban-demo-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U oban -d oban_demo"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+volumes:
+  oban-demo-pgdata:

--- a/examples/oban_app/docker-compose.yml
+++ b/examples/oban_app/docker-compose.yml
@@ -9,7 +9,9 @@ services:
     ports:
       - "5439:5432"
     volumes:
-      - oban-demo-pgdata:/var/lib/postgresql/data
+      # postgres:18+ keeps PGDATA in a versioned subdirectory; mount the parent
+      # (mounting /var/lib/postgresql/data makes the container refuse to start).
+      - oban-demo-pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U oban -d oban_demo"]
       interval: 2s

--- a/examples/oban_app/requirements.txt
+++ b/examples/oban_app/requirements.txt
@@ -1,0 +1,2 @@
+oban==0.6.2
+# Use the in-repo honeybadger build via `pip install -e ../..` instead of pinning here.

--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -68,12 +68,20 @@ class CeleryConfig:
 
 
 @dataclass
+class ObanConfig:
+    disabled: bool = False
+    exclude_workers: List[Union[str, Pattern]] = field(default_factory=list)
+    include_args: bool = False
+
+
+@dataclass
 class InsightsConfig:
     db: DBConfig = field(default_factory=DBConfig)
     django: DjangoConfig = field(default_factory=DjangoConfig)
     flask: FlaskConfig = field(default_factory=FlaskConfig)
     celery: CeleryConfig = field(default_factory=CeleryConfig)
     asgi: ASGIConfig = field(default_factory=ASGIConfig)
+    oban: ObanConfig = field(default_factory=ObanConfig)
 
 
 @dataclass

--- a/honeybadger/contrib/celery.py
+++ b/honeybadger/contrib/celery.py
@@ -3,7 +3,12 @@ import logging
 
 from honeybadger import honeybadger
 from honeybadger.plugins import Plugin, default_plugin_manager
-from honeybadger.utils import filter_dict, extract_honeybadger_config, get_duration
+from honeybadger.utils import (
+    filter_dict,
+    extract_honeybadger_config,
+    get_duration,
+    matches_any_pattern,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -150,15 +155,10 @@ class CeleryHoneybadger(object):
 
         insights_config = honeybadger.config.insights_config
 
+        # Short-circuit before touching task.name: postrun handlers can receive
+        # partial task objects (e.g. plain dicts in tests) when no excludes are set.
         exclude = insights_config.celery.exclude_tasks
-        should_exclude = exclude and any(
-            (
-                pattern.search(task.name)
-                if hasattr(pattern, "search")
-                else pattern == task.name
-            )
-            for pattern in exclude
-        )
+        should_exclude = bool(exclude) and matches_any_pattern(task.name, exclude)
 
         if (
             honeybadger.config.insights_enabled

--- a/honeybadger/contrib/oban.md
+++ b/honeybadger/contrib/oban.md
@@ -76,7 +76,7 @@ Mirrors `CeleryConfig.exclude_tasks`. Errors are independent of Insights configu
 
 | Field | Default | Effect |
 |---|---|---|
-| `disabled` | `False` | When `True`, skip all telemetry attachments at `init()`. |
+| `disabled` | `False` | When `True`, skip all telemetry attachments at `init()`. Also re-checked at emit time (alongside `insights_enabled`) so flipping it after `init()` stops events without a `tearDown()`. |
 | `exclude_workers` | `[]` | List of strings or compiled regex; matched against `job.worker` (fully-qualified `module.Class`). Filters Insights events only. |
 | `include_args` | `False` | When `True`, include filtered `job.args` and `job.meta` in `oban.job_finished` events. |
 

--- a/honeybadger/contrib/oban.md
+++ b/honeybadger/contrib/oban.md
@@ -1,0 +1,90 @@
+# Oban contrib — maintainer notes
+
+This document describes what `honeybadger/contrib/oban.py` does and the *why* behind its non-obvious choices. It's for someone maintaining or extending the contrib. End-user usage and configuration live in the project [README](../../README.md) under "Oban".
+
+## What the contrib does
+
+Hooks Honeybadger into [Oban](https://github.com/oban-bg/oban-py) so that:
+
+- Unhandled exceptions raised inside a worker's `process()` are reported to Honeybadger as errors, with the worker name, queue, args, attempt, and other job fields attached to the notice (opt-in via `report_exceptions=True`).
+- Per-job lifecycle events (`oban.job.stop`, `oban.job.exception`) and selected maintenance-loop failure events are emitted as Honeybadger Insights events when `insights_enabled=True`.
+- Any Honeybadger event context set before `Worker.enqueue(...)` / `Oban.enqueue(...)` is propagated through the job's `meta` and re-applied while the job runs and while its Insights events are emitted — so the Insights timeline can link a request to its eventual background work.
+
+## Integration surfaces
+
+Three hook points in Oban do all the work:
+
+1. **`executor.wrap_result`** — Oban's `Executor` catches every exception raised by a worker, stores it as `self.result`, then calls `use_ext("executor.wrap_result", default, job, self.result)` inside `_record_stopped`. The hook receives the live `Exception` instance — this is the only place where we can reach the real exception with its frames. Used for error reporting.
+
+2. **`oban.telemetry`** — Oban emits `oban.job.{start,stop,exception}` and several `oban.<loop>.{stage,prune,…}.{stop,exception}` events. `telemetry.attach(handler_id, [event_names], handler)` subscribes; `telemetry.detach(handler_id)` removes. Used for Insights.
+
+3. **Module-level monkey-patches** — `Oban.enqueue_many` (for write-side context injection) and each registered worker class's `process` (for read-side context application). Patched at `init()`, restored at `tearDown()`.
+
+## Lifecycle
+
+`ObanHoneybadger(report_exceptions=False).init()` wires everything; `tearDown()` reverses everything. Both are idempotent.
+
+`init()` runs under `try/except`: if any step raises (e.g. `ImportError` on Python <3.12 where oban isn't installed, or a sabotaged telemetry attach), `_cleanup_wiring()` best-effort reverts every per-target flag and the single-instance lock is released. The caller can then fix the underlying issue and retry.
+
+Only one `ObanHoneybadger` instance may be active per process at a time. A second `init()` call from a different instance raises `RuntimeError` until the prior instance is torn down.
+
+## Why the non-obvious choices
+
+### Own `ContextVar` for the current job instead of `Executor.current_job()`
+
+Oban's `_executor` exposes a `ContextVar` that's set inside `Executor._process` and reset in its `finally`. That reset runs *before* `_record_stopped` invokes `executor.wrap_result`, so `Executor.current_job()` returns `None` by the time our extension would read it. We maintain `_current_job_var` in this module and set it ourselves inside both the per-worker wrap (for user code that calls `honeybadger.notify` from within `process`) and the `wrap_result` extension (so `ObanPlugin` can enrich the auto-`notify` payload).
+
+### Three sites that apply propagated event context
+
+The per-worker wrap, the `wrap_result` extension, and the `_on_job_event` telemetry handler each apply `job.meta["honeybadger_event_context"]` via the shared `_event_context_from_meta` contextmanager. There's no single Oban hook that wraps all three call windows: the wrap fires before `process()`; `wrap_result` fires after `process()` returns; `_on_job_event` fires later still, from `_report_stopped`. Each site is self-contained. `honeybadger.event_context` is token-based, so a pre-existing context set by an outer caller is restored on exit instead of cleared.
+
+### Patch `Oban.enqueue_many` (only)
+
+Every enqueue path funnels through `Oban.enqueue_many` — `Oban.enqueue(job)` delegates to it; `Worker.enqueue` and `@job`-wrapped `enqueue` both call `Oban.get_instance(...).enqueue(...)`. Patching this single method covers transactional inserts (`conn=...`), bulk inserts, the variadic form, and both decorator surfaces. The wrapper mutates `job.meta` in place because `Job.__slots__` makes `meta` settable but doesn't enforce immutability.
+
+### Wrap worker `process` via the registry, not subclassing
+
+`oban.worker.Worker` is a `typing.Protocol`, not a base class. The `@worker` decorator registers each decorated class into `oban.worker._registry` and fires the `worker.after_register` extension. At `init()` we walk the registry once for already-decorated classes, then `put_ext("worker.after_register", …)` so future `@worker` decorations also get wrapped. The same path works uniformly for `@job` function workers (which the `@job` decorator builds as a `FunctionWorker` class then runs through `@worker`).
+
+### Extension chaining via `get_ext` / `put_ext`
+
+Oban's `_extensions` table allows only one callback per name. To coexist with other integrations (Oban Web, Oban Pro, user-installed extensions), we read the prior callback with `get_ext` before installing our own, and call it first from inside our wrapper. We deliberately let prior-callback exceptions propagate — that matches what would happen without our wrapper in place.
+
+### Wrappers go inert after `tearDown`
+
+A later integration may install its own `executor.wrap_result` extension by capturing ours via `get_ext` and calling us as its prior — i.e. *chaining into* us. After we tear down, the later integration's closure still references our handler and will keep invoking it. Our wrapper gates the auto-`notify` (and the worker-class wrapper gates worker-wrap-on-register) on `self._initialized`, so post-teardown calls become no-ops without breaking the chain.
+
+### `tearDown` identity check before restoring extensions
+
+If another integration installed its own extension *after* our `init()` (without chaining into us), `tearDown` must not clobber it. Before restoring the prior extension we compare via `is` identity to the wrapper we installed at `init()` time. If a stranger replaced us, we leave them alone.
+
+### Single-instance guard
+
+Telemetry handler IDs (`"honeybadger-oban-jobs"`, `"honeybadger-oban-loops"`) are fixed strings. Two instances would create duplicate attachments and double-fire every Insights event. Module-level `_active_instance` enforces one-active-at-a-time; the guard is the first thing `init()` checks after the same-instance early return.
+
+### `exclude_workers` filters Insights events only
+
+Mirrors `CeleryConfig.exclude_tasks`. Errors are independent of Insights configuration; if a user wants to silence a worker's errors, the right knob is `excluded_exceptions` or `before_notify` on the core config.
+
+### `include_args` deep-copies before `filter_dict`
+
+`honeybadger.utils.filter_dict` mutates nested dicts in place. Without a deep copy, redacting `password` from `job.args["user"]` would also corrupt the live Oban job that other downstream code (e.g. retry serialization) may still inspect. The same deep-copy guard is applied in `ObanPlugin.generate_payload` before assembling notice params.
+
+## Configuration
+
+`honeybadger.config.insights_config.oban` is an `ObanConfig` dataclass:
+
+| Field | Default | Effect |
+|---|---|---|
+| `disabled` | `False` | When `True`, skip all telemetry attachments at `init()`. |
+| `exclude_workers` | `[]` | List of strings or compiled regex; matched against `job.worker` (fully-qualified `module.Class`). Filters Insights events only. |
+| `include_args` | `False` | When `True`, include filtered `job.args` and `job.meta` in `oban.job_finished` events. |
+
+`ObanHoneybadger(report_exceptions=False).init()` is the constructor knob. Pass `report_exceptions=True` to install the `executor.wrap_result` extension; otherwise errors aren't auto-reported (Insights still works).
+
+## Limitations and gotchas
+
+- **Python 3.12+** — Oban's own requirement. The contrib module imports cleanly on older Pythons (all `oban.*` imports are lazy), but `init()` will raise `ImportError`. The CI matrix on 3.9-3.11 skips the test file via `pytestmark`; `mypy.ini` suppresses `import-not-found` for `oban.*` so the source typechecks on those rows too.
+- **One instance per process** — see decision above. Tests must `tearDown()` between cases; the test-suite uses a `reset_oban_registry` fixture that also clears event context to defend against cross-test pollution.
+- **`filter_dict` recursion** — `remove_keys=True` only applies at the top level (the recursive call in `honeybadger/utils.py` drops the flag). Nested matching keys are value-replaced with `"[FILTERED]"` rather than removed. Not a leak — just a behavior worth knowing when reading tests.
+- **Late-overridden `process`** — the per-worker wrap is installed on each registered class at the moment of registration (or at `init()` time). If user code later replaces `cls.process` directly, our wrapper is shadowed and that class will stop being wrapped. This is acceptable for the documented usage pattern (`@worker` then `process` defined inside the class body).

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -1,8 +1,8 @@
 """Honeybadger instrumentation for Oban-py (https://github.com/oban-bg/oban-py).
 
 Reports unhandled worker exceptions to Honeybadger and emits per-job +
-maintenance-loop telemetry to Honeybadger Insights. See the design spec:
-docs/superpowers/specs/2026-05-21-oban-py-instrumentation-design.md
+maintenance-loop telemetry to Honeybadger Insights. See the "Oban (Python)"
+section in the project README for usage and configuration.
 """
 
 import logging
@@ -125,6 +125,17 @@ class ObanHoneybadger:
     def __init__(self, report_exceptions: bool = False):
         self.report_exceptions = report_exceptions
         self._initialized = False
+        # Per-target state, initialized so that cleanup after a partial-init
+        # failure can safely inspect every flag without AttributeError.
+        self._wrapped_classes: list = []
+        self._prev_after_register = None
+        self._after_register_chain_installed = None
+        self._patched_enqueue_many = False
+        self._prev_wrap_result = None
+        self._wrap_result_extension = None
+        self._wrap_result_installed = False
+        self._job_telemetry_attached = False
+        self._loop_telemetry_attached = False
 
     def init(self):
         """Wire up extensions, telemetry, and worker wrappers. Idempotent."""
@@ -139,14 +150,27 @@ class ObanHoneybadger:
             )
         _active_instance = self
 
+        try:
+            self._perform_init()
+        except BaseException:
+            # Partial init: best-effort revert anything we wired up so far,
+            # then clear the single-instance lock so the caller can retry
+            # (or another instance can init) once the underlying issue is fixed.
+            try:
+                self._cleanup_wiring()
+            finally:
+                _active_instance = None
+            raise
+
+        self._initialized = True
+
+    def _perform_init(self):
         # Register the plugin (idempotent — PluginManager keys by name).
         default_plugin_manager.register(ObanPlugin())
 
         # Imported lazily so the module file imports cleanly without oban installed.
         from oban._extensions import get_ext, put_ext
         from oban.worker import _registry
-
-        self._wrapped_classes = []
 
         # Wrap every already-registered worker class.
         for cls in list(_registry.values()):
@@ -224,8 +248,6 @@ class ObanHoneybadger:
         else:
             self._job_telemetry_attached = False
             self._loop_telemetry_attached = False
-
-        self._initialized = True
 
     def _wrap_worker_class(self, cls):
         if getattr(cls, "_honeybadger_process_wrapped", False):
@@ -345,6 +367,11 @@ class ObanHoneybadger:
 
     @staticmethod
     def _is_worker_excluded(worker_name, patterns):
+        if not patterns:
+            # Defensive: dataclasses don't validate field types, so a user who
+            # dict-configures `exclude_workers=None` would otherwise hit a
+            # TypeError on iteration.
+            return False
         for p in patterns:
             if hasattr(p, "search"):
                 if p.search(worker_name):
@@ -356,38 +383,45 @@ class ObanHoneybadger:
     def tearDown(self):
         """Reverse all wiring done by init(). Idempotent."""
         global _active_instance
-        if not self._initialized:
-            return
         if _active_instance is not self:
             return
+        try:
+            self._cleanup_wiring()
+        finally:
+            self._initialized = False
+            _active_instance = None
 
-        from oban._extensions import put_ext
+    def _cleanup_wiring(self):
+        """Best-effort revert of every per-target wiring step.
 
-        # Restore Oban.enqueue_many if we patched it.
-        from oban import Oban
+        Safe to call after a partial init() failure as well as from tearDown().
+        Each step is gated by its own flag so absent state is a no-op.
+        """
+        # Lazy imports: cleanup may run after a failed init where oban itself
+        # wasn't importable, but in that case nothing got wired and every flag
+        # is its initial value, so all per-target blocks below are no-ops and
+        # we never reach the imports.
+        if self._patched_enqueue_many:
+            from oban import Oban
 
-        if getattr(self, "_patched_enqueue_many", False):
             if getattr(Oban.enqueue_many, "_honeybadger_patched", False):
                 Oban.enqueue_many = Oban.enqueue_many._honeybadger_original
             self._patched_enqueue_many = False
 
-        # Detach Insights job-event handler.
-        if getattr(self, "_job_telemetry_attached", False):
+        if self._job_telemetry_attached:
             from oban import telemetry
 
             telemetry.detach("honeybadger-oban-jobs")
             self._job_telemetry_attached = False
 
-        # Detach Insights loop-exception handler.
-        if getattr(self, "_loop_telemetry_attached", False):
+        if self._loop_telemetry_attached:
             from oban import telemetry
 
             telemetry.detach("honeybadger-oban-loops")
             self._loop_telemetry_attached = False
 
-        # Restore executor.wrap_result extension.
-        if getattr(self, "_wrap_result_installed", False):
-            from oban._extensions import get_ext
+        if self._wrap_result_installed:
+            from oban._extensions import get_ext, put_ext
 
             current = get_ext("executor.wrap_result", None)
             if current is self._wrap_result_extension:
@@ -395,12 +429,14 @@ class ObanHoneybadger:
             # else: a later integration replaced our extension; leave it alone.
             self._wrap_result_installed = False
 
-        # Restore worker.after_register to whatever was there before.
-        from oban._extensions import get_ext
+        if self._after_register_chain_installed is not None:
+            from oban._extensions import get_ext, put_ext
 
-        current = get_ext("worker.after_register", None)
-        if current is self._after_register_chain_installed:
-            put_ext("worker.after_register", self._prev_after_register)
+            current = get_ext("worker.after_register", None)
+            if current is self._after_register_chain_installed:
+                put_ext("worker.after_register", self._prev_after_register)
+            self._after_register_chain_installed = None
+            self._prev_after_register = None
 
         # Unwrap every worker class we wrapped.
         for cls in self._wrapped_classes:
@@ -409,6 +445,3 @@ class ObanHoneybadger:
                 del cls._honeybadger_original_process
                 del cls._honeybadger_process_wrapped
         self._wrapped_classes = []
-
-        self._initialized = False
-        _active_instance = None

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -1,8 +1,10 @@
-"""Honeybadger instrumentation for Oban-py (https://github.com/oban-bg/oban-py).
+"""Honeybadger instrumentation for Oban (https://github.com/oban-bg/oban-py).
 
 Reports unhandled worker exceptions to Honeybadger and emits per-job +
-maintenance-loop telemetry to Honeybadger Insights. See the Oban
-section in the project README for usage and configuration.
+maintenance-loop telemetry to Honeybadger Insights.
+
+End-user usage and configuration: see the Oban section in the project README.
+Design and rationale (for maintainers): see oban.md alongside this file.
 """
 
 import logging
@@ -27,7 +29,9 @@ _current_job_var: ContextVar[Optional["Job"]] = ContextVar(
     "honeybadger_oban_current_job", default=None
 )
 
-# Module-level single-instance guard (see decision #12 in the spec).
+# Module-level single-instance guard. Telemetry handler IDs are fixed strings,
+# so two live instances would create duplicate attachments and double-fire every
+# Insights event. See "Single-instance guard" in oban.md.
 _active_instance: Optional["ObanHoneybadger"] = None
 
 _LOOP_EXCEPTION_EVENTS = (
@@ -113,7 +117,7 @@ class ObanPlugin(Plugin):
 
 
 class ObanHoneybadger:
-    """Wires Honeybadger into Oban-py.
+    """Wires Honeybadger into Oban.
 
     Usage:
 
@@ -140,7 +144,7 @@ class ObanHoneybadger:
     def init(self):
         """Wire up extensions, telemetry, and worker wrappers. Idempotent."""
         if self._initialized:
-            return  # same-instance early return; see spec decision #12
+            return  # same-instance early return; see oban.md
 
         global _active_instance
         if _active_instance is not None and _active_instance is not self:

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -271,7 +271,11 @@ class ObanHoneybadger:
 
     def _after_register_chain(self, cls):
         # Call the prior extension first (the decorator's default is a no-op).
-        self._prev_after_register(cls)
+        # _prev_after_register may be None after _cleanup_wiring() runs, if a
+        # later integration captured this method via the chain pattern and
+        # keeps calling it post-teardown.
+        if self._prev_after_register is not None:
+            self._prev_after_register(cls)
         if not self._initialized:
             return  # torn down; do not wrap further workers
         self._wrap_worker_class(cls)

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Optional
 
 from honeybadger import honeybadger
 from honeybadger.plugins import Plugin, default_plugin_manager
+from honeybadger.utils import filter_dict
 
 if TYPE_CHECKING:
     from oban.job import Job  # type: ignore[import-not-found]
@@ -93,8 +94,6 @@ class ObanPlugin(Plugin):
 
         # Filter sensitive keys (e.g. password) before including in the notice
         # payload. Deep-copy first because filter_dict mutates nested dicts in place.
-        from honeybadger.utils import filter_dict
-
         params_filters = honeybadger.config.params_filters
 
         def _filter(value):
@@ -313,7 +312,8 @@ class ObanHoneybadger:
 
     def _on_job_event(self, name, meta):
         try:
-            from honeybadger.utils import filter_dict
+            if not self._insights_active():
+                return
 
             job = meta["job"]
             oban_cfg = honeybadger.config.insights_config.oban
@@ -355,6 +355,9 @@ class ObanHoneybadger:
 
     def _on_loop_exception(self, name, meta):
         try:
+            if not self._insights_active():
+                return
+
             # name == "oban.<loop>.<action>.exception"
             parts = name.split(".")
             if len(parts) < 4:
@@ -372,6 +375,14 @@ class ObanHoneybadger:
             )
         except Exception:
             logger.exception("Failed to emit Oban loop-exception event for %s", name)
+
+    @staticmethod
+    def _insights_active():
+        # Re-check at emit time, not just at attach time: config is mutable, so
+        # a user can flip insights_enabled or oban.disabled after init() without
+        # tearing down. Guards both telemetry handlers.
+        config = honeybadger.config
+        return config.insights_enabled and not config.insights_config.oban.disabled
 
     @staticmethod
     def _is_worker_excluded(worker_name, patterns):

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Optional
 
 from honeybadger import honeybadger
 from honeybadger.plugins import Plugin, default_plugin_manager
-from honeybadger.utils import filter_dict
+from honeybadger.utils import filter_dict, matches_any_pattern
 
 if TYPE_CHECKING:
     from oban.job import Job  # type: ignore[import-not-found]
@@ -43,8 +43,18 @@ _LOOP_EXCEPTION_EVENTS = (
     "oban.refresher.refresh.exception",
     "oban.refresher.cleanup.exception",
     "oban.scheduler.evaluate.exception",
-    "oban.producer.fetch.exception",
+    "oban.producer.get.exception",
+    "oban.producer.ack.exception",
 )
+
+
+def _filtered_copy(value, params_filters):
+    """Filter sensitive keys (e.g. password) out of a dict before including it
+    in a notice or event. Deep-copies first because filter_dict mutates nested
+    dicts in place; non-dict values pass through unchanged."""
+    if isinstance(value, dict):
+        return filter_dict(deepcopy(value), params_filters, remove_keys=True)
+    return value
 
 
 @contextmanager
@@ -92,22 +102,14 @@ class ObanPlugin(Plugin):
             tags=job.tags,
         )
 
-        # Filter sensitive keys (e.g. password) before including in the notice
-        # payload. Deep-copy first because filter_dict mutates nested dicts in place.
         params_filters = honeybadger.config.params_filters
-
-        def _filter(value):
-            if isinstance(value, dict):
-                return filter_dict(deepcopy(value), params_filters, remove_keys=True)
-            return value
-
         default_payload["request"].update(
             {
                 "component": module,
                 "action": worker_name,
                 "params": {
-                    "args": _filter(job.args),
-                    "meta": _filter(job.meta),
+                    "args": _filtered_copy(job.args, params_filters),
+                    "meta": _filtered_copy(job.meta, params_filters),
                 },
                 "context": merged_context,
             }
@@ -337,15 +339,10 @@ class ObanHoneybadger:
                 payload["error_message"] = meta.get("error_message")
 
             if oban_cfg.include_args:
-                payload["args"] = filter_dict(
-                    deepcopy(job.args) if isinstance(job.args, dict) else job.args,
-                    honeybadger.config.params_filters,
-                    remove_keys=True,
-                )
-                payload["meta"] = filter_dict(
-                    deepcopy(job.meta) if isinstance(job.meta, dict) else {},
-                    honeybadger.config.params_filters,
-                    remove_keys=True,
+                params_filters = honeybadger.config.params_filters
+                payload["args"] = _filtered_copy(job.args, params_filters)
+                payload["meta"] = _filtered_copy(
+                    job.meta if isinstance(job.meta, dict) else {}, params_filters
                 )
 
             with _event_context_from_meta(job):
@@ -386,18 +383,7 @@ class ObanHoneybadger:
 
     @staticmethod
     def _is_worker_excluded(worker_name, patterns):
-        if not patterns:
-            # Defensive: dataclasses don't validate field types, so a user who
-            # dict-configures `exclude_workers=None` would otherwise hit a
-            # TypeError on iteration.
-            return False
-        for p in patterns:
-            if hasattr(p, "search"):
-                if p.search(worker_name):
-                    return True
-            elif p == worker_name:
-                return True
-        return False
+        return matches_any_pattern(worker_name, patterns)
 
     def tearDown(self):
         """Reverse all wiring done by init(). Idempotent."""

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -1,7 +1,7 @@
 """Honeybadger instrumentation for Oban-py (https://github.com/oban-bg/oban-py).
 
 Reports unhandled worker exceptions to Honeybadger and emits per-job +
-maintenance-loop telemetry to Honeybadger Insights. See the "Oban (Python)"
+maintenance-loop telemetry to Honeybadger Insights. See the Oban
 section in the project README for usage and configuration.
 """
 

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -1,0 +1,414 @@
+"""Honeybadger instrumentation for Oban-py (https://github.com/oban-bg/oban-py).
+
+Reports unhandled worker exceptions to Honeybadger and emits per-job +
+maintenance-loop telemetry to Honeybadger Insights. See the design spec:
+docs/superpowers/specs/2026-05-21-oban-py-instrumentation-design.md
+"""
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from copy import deepcopy
+from typing import TYPE_CHECKING, Optional
+
+from honeybadger import honeybadger
+from honeybadger.plugins import Plugin, default_plugin_manager
+
+if TYPE_CHECKING:
+    from oban.job import Job  # type: ignore[import-not-found]
+
+logger = logging.getLogger(__name__)
+
+# Set by:
+#   - The per-worker process wrapper (during user-code execution)
+#   - The executor.wrap_result extension (during the auto-notify call)
+# Read by ObanPlugin.supports/generate_payload.
+_current_job_var: ContextVar[Optional["Job"]] = ContextVar(
+    "honeybadger_oban_current_job", default=None
+)
+
+# Module-level single-instance guard (see decision #12 in the spec).
+_active_instance: Optional["ObanHoneybadger"] = None
+
+_LOOP_EXCEPTION_EVENTS = (
+    "oban.leader.election.exception",
+    "oban.stager.stage.exception",
+    "oban.lifeline.rescue.exception",
+    "oban.pruner.prune.exception",
+    "oban.refresher.refresh.exception",
+    "oban.refresher.cleanup.exception",
+    "oban.scheduler.evaluate.exception",
+    "oban.producer.fetch.exception",
+)
+
+
+@contextmanager
+def _event_context_from_meta(job):
+    """Temporarily merge propagated event context from job.meta, if any.
+
+    Uses honeybadger.event_context (token-based ContextVar) so any pre-existing
+    event context is restored on exit, not cleared.
+    """
+    if not isinstance(getattr(job, "meta", None), dict):
+        yield
+        return
+    ctx = job.meta.get("honeybadger_event_context")
+    if not isinstance(ctx, dict):
+        yield
+        return
+    with honeybadger.event_context(ctx):
+        yield
+
+
+class ObanPlugin(Plugin):
+    def __init__(self):
+        super().__init__("Oban")
+
+    def supports(self, config, context):
+        return _current_job_var.get() is not None
+
+    def generate_payload(self, default_payload, config, context):
+        job = _current_job_var.get()
+        if job is None:
+            return default_payload
+
+        worker_name = job.worker  # "module.qualname" string from oban
+        if "." in worker_name:
+            module = worker_name.rsplit(".", 1)[0]
+        else:
+            module = worker_name
+
+        merged_context = dict(context or {})
+        merged_context.update(
+            job_id=job.id,
+            queue=job.queue,
+            attempt=job.attempt,
+            max_attempts=job.max_attempts,
+            tags=job.tags,
+        )
+
+        # Filter sensitive keys (e.g. password) before including in the notice
+        # payload. Deep-copy first because filter_dict mutates nested dicts in place.
+        from honeybadger.utils import filter_dict
+
+        params_filters = honeybadger.config.params_filters
+
+        def _filter(value):
+            if isinstance(value, dict):
+                return filter_dict(deepcopy(value), params_filters, remove_keys=True)
+            return value
+
+        default_payload["request"].update(
+            {
+                "component": module,
+                "action": worker_name,
+                "params": {
+                    "args": _filter(job.args),
+                    "meta": _filter(job.meta),
+                },
+                "context": merged_context,
+            }
+        )
+        return default_payload
+
+
+class ObanHoneybadger:
+    """Wires Honeybadger into Oban-py.
+
+    Usage:
+
+        ObanHoneybadger(report_exceptions=True).init()
+
+    Only one instance may be active per process at a time.
+    """
+
+    def __init__(self, report_exceptions: bool = False):
+        self.report_exceptions = report_exceptions
+        self._initialized = False
+
+    def init(self):
+        """Wire up extensions, telemetry, and worker wrappers. Idempotent."""
+        if self._initialized:
+            return  # same-instance early return; see spec decision #12
+
+        global _active_instance
+        if _active_instance is not None and _active_instance is not self:
+            raise RuntimeError(
+                "ObanHoneybadger already initialized; "
+                "call tearDown() on the previous instance first"
+            )
+        _active_instance = self
+
+        # Register the plugin (idempotent — PluginManager keys by name).
+        default_plugin_manager.register(ObanPlugin())
+
+        # Imported lazily so the module file imports cleanly without oban installed.
+        from oban._extensions import get_ext, put_ext
+        from oban.worker import _registry
+
+        self._wrapped_classes = []
+
+        # Wrap every already-registered worker class.
+        for cls in list(_registry.values()):
+            self._wrap_worker_class(cls)
+
+        # Chain into worker.after_register so future workers are wrapped too.
+        self._prev_after_register = get_ext("worker.after_register", lambda _cls: None)
+        self._after_register_chain_installed = self._after_register_chain
+        put_ext("worker.after_register", self._after_register_chain_installed)
+
+        # Patch Oban.enqueue_many for write-side event-context propagation.
+        from oban import Oban
+        from oban.job import Job
+
+        if not getattr(Oban.enqueue_many, "_honeybadger_patched", False):
+            original_enqueue_many = Oban.enqueue_many
+
+            async def _wrapped_enqueue_many(
+                self_inner, jobs_or_first, /, *rest, conn=None
+            ):
+                ctx = honeybadger._get_event_context()
+                if ctx:
+                    if isinstance(jobs_or_first, Job):
+                        jobs_iter = [jobs_or_first, *rest]
+                    else:
+                        jobs_iter = list(jobs_or_first)
+                        # We've consumed the iterable; pass it back as a list.
+                        jobs_or_first = jobs_iter
+                        rest = ()
+                    for job in jobs_iter:
+                        base = job.meta if isinstance(job.meta, dict) else {}
+                        job.meta = {**base, "honeybadger_event_context": dict(ctx)}
+                return await original_enqueue_many(
+                    self_inner, jobs_or_first, *rest, conn=conn
+                )
+
+            _wrapped_enqueue_many._honeybadger_patched = True
+            _wrapped_enqueue_many._honeybadger_original = original_enqueue_many
+            Oban.enqueue_many = _wrapped_enqueue_many
+            self._patched_enqueue_many = True
+        else:
+            self._patched_enqueue_many = False
+
+        # executor.wrap_result extension for error reporting.
+        if self.report_exceptions:
+            self._prev_wrap_result = get_ext(
+                "executor.wrap_result", lambda _job, result: result
+            )
+            self._wrap_result_extension = self._make_wrap_result_extension()
+            put_ext("executor.wrap_result", self._wrap_result_extension)
+            self._wrap_result_installed = True
+        else:
+            self._wrap_result_installed = False
+
+        # Insights telemetry handlers.
+        insights_enabled = (
+            honeybadger.config.insights_enabled
+            and not honeybadger.config.insights_config.oban.disabled
+        )
+        if insights_enabled:
+            from oban import telemetry
+
+            telemetry.attach(
+                "honeybadger-oban-jobs",
+                ["oban.job.stop", "oban.job.exception"],
+                self._on_job_event,
+            )
+            self._job_telemetry_attached = True
+            telemetry.attach(
+                "honeybadger-oban-loops",
+                list(_LOOP_EXCEPTION_EVENTS),
+                self._on_loop_exception,
+            )
+            self._loop_telemetry_attached = True
+        else:
+            self._job_telemetry_attached = False
+            self._loop_telemetry_attached = False
+
+        self._initialized = True
+
+    def _wrap_worker_class(self, cls):
+        if getattr(cls, "_honeybadger_process_wrapped", False):
+            return
+        original = cls.process
+        cls._honeybadger_original_process = original
+        cls.process = self._make_wrapped_process(original)
+        cls._honeybadger_process_wrapped = True
+        self._wrapped_classes.append(cls)
+
+    def _make_wrapped_process(self, original):
+        async def _wrapped_process(worker_self, job):
+            job_token = _current_job_var.set(job)
+            try:
+                with _event_context_from_meta(job):
+                    return await original(worker_self, job)
+            finally:
+                _current_job_var.reset(job_token)
+
+        return _wrapped_process
+
+    def _after_register_chain(self, cls):
+        # Call the prior extension first (the decorator's default is a no-op).
+        self._prev_after_register(cls)
+        if not self._initialized:
+            return  # torn down; do not wrap further workers
+        self._wrap_worker_class(cls)
+
+    def _make_wrap_result_extension(self):
+        prev = self._prev_wrap_result
+        hb_oban = self  # closure ref so we can check liveness after teardown
+
+        def _wrap_result(job, result):
+            # Chain prior extension first; let its exceptions propagate so we
+            # preserve prior Oban behavior bit-for-bit.
+            result = prev(job, result)
+
+            if not hb_oban._initialized:
+                # Honeybadger was torn down; remain inert but still chain prev so
+                # later integrations that captured us by reference don't break.
+                return result
+
+            if isinstance(result, Exception):
+                job_token = _current_job_var.set(job)
+                try:
+                    with _event_context_from_meta(job):
+                        honeybadger.notify(exception=result)
+                except Exception:
+                    logger.exception("Failed to report Oban exception to Honeybadger")
+                finally:
+                    _current_job_var.reset(job_token)
+            return result
+
+        return _wrap_result
+
+    def _on_job_event(self, name, meta):
+        try:
+            from honeybadger.utils import filter_dict
+
+            job = meta["job"]
+            oban_cfg = honeybadger.config.insights_config.oban
+
+            if self._is_worker_excluded(job.worker, oban_cfg.exclude_workers):
+                return
+
+            payload = {
+                "job_id": job.id,
+                "worker": job.worker,
+                "queue": job.queue,
+                "state": meta.get("state"),
+                "attempt": job.attempt,
+                "max_attempts": job.max_attempts,
+                "duration": meta.get("duration", 0) / 1_000_000,
+                "queue_time": meta.get("queue_time", 0) / 1_000_000,
+                "tags": job.tags,
+            }
+            if name == "oban.job.exception":
+                payload["error_type"] = meta.get("error_type")
+                payload["error_message"] = meta.get("error_message")
+
+            if oban_cfg.include_args:
+                payload["args"] = filter_dict(
+                    deepcopy(job.args) if isinstance(job.args, dict) else job.args,
+                    honeybadger.config.params_filters,
+                    remove_keys=True,
+                )
+                payload["meta"] = filter_dict(
+                    deepcopy(job.meta) if isinstance(job.meta, dict) else {},
+                    honeybadger.config.params_filters,
+                    remove_keys=True,
+                )
+
+            with _event_context_from_meta(job):
+                honeybadger.event("oban.job_finished", payload)
+        except Exception:
+            logger.exception("Failed to emit Oban Insights event for %s", name)
+
+    def _on_loop_exception(self, name, meta):
+        try:
+            # name == "oban.<loop>.<action>.exception"
+            parts = name.split(".")
+            if len(parts) < 4:
+                return
+            loop = parts[1]
+            honeybadger.event(
+                f"oban.{loop}_exception",
+                {
+                    "loop": loop,
+                    "event": name,
+                    "error_type": meta.get("error_type"),
+                    "error_message": meta.get("error_message"),
+                    "duration": meta.get("duration", 0) / 1_000_000,
+                },
+            )
+        except Exception:
+            logger.exception("Failed to emit Oban loop-exception event for %s", name)
+
+    @staticmethod
+    def _is_worker_excluded(worker_name, patterns):
+        for p in patterns:
+            if hasattr(p, "search"):
+                if p.search(worker_name):
+                    return True
+            elif p == worker_name:
+                return True
+        return False
+
+    def tearDown(self):
+        """Reverse all wiring done by init(). Idempotent."""
+        global _active_instance
+        if not self._initialized:
+            return
+        if _active_instance is not self:
+            return
+
+        from oban._extensions import put_ext
+
+        # Restore Oban.enqueue_many if we patched it.
+        from oban import Oban
+
+        if getattr(self, "_patched_enqueue_many", False):
+            if getattr(Oban.enqueue_many, "_honeybadger_patched", False):
+                Oban.enqueue_many = Oban.enqueue_many._honeybadger_original
+            self._patched_enqueue_many = False
+
+        # Detach Insights job-event handler.
+        if getattr(self, "_job_telemetry_attached", False):
+            from oban import telemetry
+
+            telemetry.detach("honeybadger-oban-jobs")
+            self._job_telemetry_attached = False
+
+        # Detach Insights loop-exception handler.
+        if getattr(self, "_loop_telemetry_attached", False):
+            from oban import telemetry
+
+            telemetry.detach("honeybadger-oban-loops")
+            self._loop_telemetry_attached = False
+
+        # Restore executor.wrap_result extension.
+        if getattr(self, "_wrap_result_installed", False):
+            from oban._extensions import get_ext
+
+            current = get_ext("executor.wrap_result", None)
+            if current is self._wrap_result_extension:
+                put_ext("executor.wrap_result", self._prev_wrap_result)
+            # else: a later integration replaced our extension; leave it alone.
+            self._wrap_result_installed = False
+
+        # Restore worker.after_register to whatever was there before.
+        from oban._extensions import get_ext
+
+        current = get_ext("worker.after_register", None)
+        if current is self._after_register_chain_installed:
+            put_ext("worker.after_register", self._prev_after_register)
+
+        # Unwrap every worker class we wrapped.
+        for cls in self._wrapped_classes:
+            if getattr(cls, "_honeybadger_process_wrapped", False):
+                cls.process = cls._honeybadger_original_process
+                del cls._honeybadger_original_process
+                del cls._honeybadger_process_wrapped
+        self._wrapped_classes = []
+
+        self._initialized = False
+        _active_instance = None

--- a/honeybadger/contrib/oban.py
+++ b/honeybadger/contrib/oban.py
@@ -99,8 +99,17 @@ class ObanPlugin(Plugin):
             queue=job.queue,
             attempt=job.attempt,
             max_attempts=job.max_attempts,
-            tags=job.tags,
         )
+
+        # Job tags become fault tags via the real tags channel (error.tags).
+        # Never put them in context: the server treats context["tags"] as a
+        # reserved key holding a comma-separated string, and stringifies a
+        # list into junk tags like "[]" or '["alpha"'.
+        if job.tags:
+            error_tags = default_payload.setdefault("error", {}).setdefault("tags", [])
+            error_tags.extend(
+                t for t in job.tags if isinstance(t, str) and t not in error_tags
+            )
 
         params_filters = honeybadger.config.params_filters
         default_payload["request"].update(

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -667,6 +667,64 @@ async def test_exclude_workers_filters_insights_events(
 
 
 @pytest.mark.asyncio
+async def test_job_event_skipped_when_insights_disabled_at_runtime(
+    reset_oban_registry, with_insights
+):
+    """Config is mutable: flipping oban.disabled after init() must stop events
+    even though the telemetry handler is still attached."""
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class RuntimeOffW:
+        async def process(self, job):
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        # Disable AFTER init (handler is already attached).
+        hb_module.config.insights_config.oban.disabled = True
+
+        job = Job(
+            "RuntimeOffW",
+            args={},
+            id=99,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 0,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                },
+            )
+            telemetry.execute(
+                "oban.scheduler.evaluate.exception",
+                {
+                    "monotonic_time": 0,
+                    "duration": 0,
+                    "error_type": "E",
+                    "error_message": "m",
+                    "traceback": "t",
+                },
+            )
+        assert event.call_count == 0
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
 async def test_include_args_filters_sensitive_keys(reset_oban_registry, with_insights):
     from oban import worker, telemetry
     from oban.job import Job

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -58,7 +58,63 @@ def test_plugin_generate_payload_enriches_with_job_fields():
     assert request["context"]["queue"] == "mailers"
     assert request["context"]["attempt"] == 2
     assert request["context"]["max_attempts"] == 5
-    assert request["context"]["tags"] == ["email", "transactional"]
+    # Tags must flow through error.tags (real fault tags), never context["tags"]:
+    # the server treats that context key as a comma-separated string and
+    # stringifies lists into junk tags like "[]".
+    assert "tags" not in request["context"]
+    assert payload["error"]["tags"] == ["email", "transactional"]
+
+
+def test_plugin_generate_payload_merges_job_tags_into_existing_error_tags():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.id = 1
+    job.worker = "MyW"
+    job.queue = "default"
+    job.attempt = 1
+    job.max_attempts = 5
+    job.args = {}
+    job.meta = {}
+    job.tags = ["email", "urgent"]
+
+    token = _current_job_var.set(job)
+    try:
+        plugin = ObanPlugin()
+        payload = plugin.generate_payload(
+            {"request": {}, "error": {"tags": ["urgent"]}}, {}, {}
+        )
+    finally:
+        _current_job_var.reset(token)
+
+    # notify()-provided tags are kept; job tags appended without duplicates.
+    assert payload["error"]["tags"] == ["urgent", "email"]
+
+
+def test_plugin_generate_payload_omits_tags_when_job_has_none():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.id = 1
+    job.worker = "MyW"
+    job.queue = "default"
+    job.attempt = 1
+    job.max_attempts = 5
+    job.args = {}
+    job.meta = {}
+    job.tags = []
+
+    token = _current_job_var.set(job)
+    try:
+        plugin = ObanPlugin()
+        payload = plugin.generate_payload({"request": {}}, {}, {})
+    finally:
+        _current_job_var.reset(token)
+
+    assert "tags" not in payload["request"]["context"]
+    assert "error" not in payload  # nothing injected for tagless jobs
 
 
 def test_event_context_from_meta_is_noop_when_no_context():

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -1,0 +1,1111 @@
+import sys
+from unittest.mock import patch
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="oban requires Python 3.12+"
+)
+
+
+def test_plugin_supports_returns_false_outside_job():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+
+    assert _current_job_var.get() is None
+    plugin = ObanPlugin()
+    assert plugin.supports({}, {}) is False
+
+
+def test_plugin_supports_returns_true_when_current_job_set():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    token = _current_job_var.set(job)
+    try:
+        plugin = ObanPlugin()
+        assert plugin.supports({}, {}) is True
+    finally:
+        _current_job_var.reset(token)
+
+
+def test_plugin_generate_payload_enriches_with_job_fields():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.id = 42
+    job.worker = "myapp.workers.SendEmail"
+    job.queue = "mailers"
+    job.attempt = 2
+    job.max_attempts = 5
+    job.args = {"to": "user@example.com"}
+    job.meta = {"foo": "bar"}
+    job.tags = ["email", "transactional"]
+
+    token = _current_job_var.set(job)
+    try:
+        plugin = ObanPlugin()
+        payload = plugin.generate_payload({"request": {}}, {}, {})
+    finally:
+        _current_job_var.reset(token)
+
+    request = payload["request"]
+    assert request["component"] == "myapp.workers"
+    assert request["action"] == "myapp.workers.SendEmail"
+    assert request["params"]["args"] == {"to": "user@example.com"}
+    assert request["params"]["meta"] == {"foo": "bar"}
+    assert request["context"]["job_id"] == 42
+    assert request["context"]["queue"] == "mailers"
+    assert request["context"]["attempt"] == 2
+    assert request["context"]["max_attempts"] == 5
+    assert request["context"]["tags"] == ["email", "transactional"]
+
+
+def test_event_context_from_meta_is_noop_when_no_context():
+    from honeybadger.contrib.oban import _event_context_from_meta
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.meta = {}
+    # Should not raise; should be a usable context manager that yields.
+    with _event_context_from_meta(job):
+        pass
+
+
+def test_event_context_from_meta_sets_context_when_present():
+    from honeybadger import honeybadger
+    from honeybadger.contrib.oban import _event_context_from_meta
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.meta = {"honeybadger_event_context": {"request_id": "abc-123"}}
+    # Snapshot before
+    before = honeybadger._get_event_context()
+    with _event_context_from_meta(job):
+        assert honeybadger._get_event_context().get("request_id") == "abc-123"
+    # After block, original context is restored
+    assert honeybadger._get_event_context() == before
+
+
+def test_event_context_from_meta_ignores_non_dict_meta():
+    from honeybadger.contrib.oban import _event_context_from_meta
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.meta = None
+    with _event_context_from_meta(job):
+        pass  # must not raise
+
+
+@pytest.fixture
+def reset_oban_registry():
+    """Clear the worker registry and our active-instance state before each test."""
+    from oban.worker import _registry
+    from oban._extensions import _extensions
+    import honeybadger.contrib.oban as hb_oban
+
+    _registry.clear()
+    _extensions.clear()
+    hb_oban._active_instance = None
+    yield
+    _registry.clear()
+    _extensions.clear()
+    hb_oban._active_instance = None
+
+
+def test_construction_without_init_does_not_register_plugin(reset_oban_registry):
+    from honeybadger.plugins import default_plugin_manager
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    # Snapshot before
+    had_oban = "Oban" in default_plugin_manager._registered
+
+    ObanHoneybadger()  # construction only, no init
+
+    if not had_oban:
+        # Construction alone should not have added the plugin.
+        assert "Oban" not in default_plugin_manager._registered
+
+
+@pytest.mark.asyncio
+async def test_init_wraps_existing_worker_process(reset_oban_registry):
+    from oban import worker
+    from honeybadger.contrib.oban import ObanHoneybadger, _current_job_var
+
+    captured = {}
+
+    @worker(queue="default")
+    class W:
+        async def process(self, job):
+            captured["job_in_process"] = _current_job_var.get()
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        from oban.job import Job
+
+        job = Job("W", args={})
+        instance = W()
+        await instance.process(job)
+        assert captured["job_in_process"] is job
+        # After process returns, the ContextVar must be reset.
+        assert _current_job_var.get() is None
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_init_wraps_worker_registered_after_init(reset_oban_registry):
+    from oban import worker
+    from honeybadger.contrib.oban import ObanHoneybadger, _current_job_var
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        captured = {}
+
+        @worker(queue="default")
+        class LateW:
+            async def process(self, job):
+                captured["job_in_process"] = _current_job_var.get()
+                return None
+
+        from oban.job import Job
+
+        job = Job("LateW", args={})
+        await LateW().process(job)
+        assert captured["job_in_process"] is job
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_wrapped_process_applies_event_context_from_meta(reset_oban_registry):
+    from oban import worker
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    captured = {}
+
+    @worker(queue="default")
+    class CtxW:
+        async def process(self, job):
+            captured["ctx_during"] = hb_module._get_event_context().copy()
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        from oban.job import Job
+
+        job = Job(
+            "CtxW", args={}, meta={"honeybadger_event_context": {"request_id": "r-1"}}
+        )
+        await CtxW().process(job)
+        assert captured["ctx_during"].get("request_id") == "r-1"
+        # After process, event context is restored.
+        assert hb_module._get_event_context().get("request_id") is None
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_teardown_unwraps_worker_process(reset_oban_registry):
+    from oban import worker
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class W2:
+        async def process(self, job):
+            return None
+
+    original_process = W2.process
+
+    hb = ObanHoneybadger()
+    hb.init()
+    assert W2.process is not original_process  # wrapped
+
+    hb.tearDown()
+    assert W2.process is original_process  # restored
+
+
+@pytest.mark.asyncio
+async def test_enqueue_many_injects_event_context_when_set(reset_oban_registry):
+    from oban import Oban, worker
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class EW:
+        async def process(self, job):
+            return None
+
+    # Stand up an Oban instance without a real pool by mocking the insert.
+    from unittest.mock import AsyncMock, MagicMock
+
+    oban_inst = Oban.__new__(Oban)
+    oban_inst._query = MagicMock()
+    oban_inst._query.insert_jobs = AsyncMock(side_effect=lambda jobs, conn=None: jobs)
+    oban_inst._producers = {}
+    oban_inst._name = "Oban"
+    Oban._instances = {"Oban": oban_inst}  # for any code that calls get_instance
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        hb_module.set_event_context({"request_id": "req-9"})
+        try:
+            job = Job("EW", args={"x": 1})
+            result = await oban_inst.enqueue_many([job])
+        finally:
+            hb_module.reset_event_context()
+
+        assert result[0].meta.get("honeybadger_event_context") == {
+            "request_id": "req-9"
+        }
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_many_leaves_meta_unchanged_without_event_context(
+    reset_oban_registry,
+):
+    from oban import Oban, worker
+    from oban.job import Job
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class EW2:
+        async def process(self, job):
+            return None
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    oban_inst = Oban.__new__(Oban)
+    oban_inst._query = MagicMock()
+    oban_inst._query.insert_jobs = AsyncMock(side_effect=lambda jobs, conn=None: jobs)
+    oban_inst._producers = {}
+    oban_inst._name = "Oban"
+    Oban._instances = {"Oban": oban_inst}
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job("EW2", args={"x": 2}, meta={"custom": "value"})
+        result = await oban_inst.enqueue_many([job])
+        # Original meta preserved; no injection happened.
+        assert result[0].meta == {"custom": "value"}
+        assert "honeybadger_event_context" not in result[0].meta
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_many_handles_variadic_form(reset_oban_registry):
+    from oban import Oban, worker
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class EW3:
+        async def process(self, job):
+            return None
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    oban_inst = Oban.__new__(Oban)
+    oban_inst._query = MagicMock()
+    oban_inst._query.insert_jobs = AsyncMock(side_effect=lambda jobs, conn=None: jobs)
+    oban_inst._producers = {}
+    oban_inst._name = "Oban"
+    Oban._instances = {"Oban": oban_inst}
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        hb_module.set_event_context({"request_id": "req-multi"})
+        try:
+            j1 = Job("EW3", args={"x": 1})
+            j2 = Job("EW3", args={"x": 2})
+            result = await oban_inst.enqueue_many(j1, j2)
+        finally:
+            hb_module.reset_event_context()
+
+        assert len(result) == 2
+        for j in result:
+            assert j.meta.get("honeybadger_event_context") == {
+                "request_id": "req-multi"
+            }
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_teardown_restores_original_enqueue_many(reset_oban_registry):
+    from oban import Oban
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    original = Oban.enqueue_many
+    hb = ObanHoneybadger()
+    hb.init()
+    assert Oban.enqueue_many is not original
+    hb.tearDown()
+    assert Oban.enqueue_many is original
+
+
+@pytest.mark.asyncio
+async def test_wrap_result_reports_exception_for_worker_class(reset_oban_registry):
+    from oban import worker
+    from oban.job import Job
+    from oban._executor import Executor
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class FailW:
+        async def process(self, job):
+            raise ValueError("boom")
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+    try:
+        job = Job("FailW", args={}, id=1, attempt=1)
+        with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
+            await Executor(job).execute()
+        assert notify.call_count == 1
+        assert isinstance(notify.call_args[1]["exception"], ValueError)
+        assert str(notify.call_args[1]["exception"]) == "boom"
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_wrap_result_reports_exception_for_job_function(reset_oban_registry):
+    from oban import job as job_decorator
+    from oban.job import Job
+    from oban._executor import Executor
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @job_decorator(queue="default")
+    def send_email(to: str):
+        raise RuntimeError("nope")
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+    try:
+        # @job builds a FunctionWorker registered under the function's qualname.
+        from oban.worker import _registry
+
+        worker_name = next(iter(_registry))
+        job_inst = Job(worker_name, args={"to": "x@example.com"}, id=2, attempt=1)
+        with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
+            await Executor(job_inst).execute()
+        assert notify.call_count == 1
+        assert isinstance(notify.call_args[1]["exception"], RuntimeError)
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_no_notify_when_report_exceptions_false(reset_oban_registry):
+    from oban import worker
+    from oban.job import Job
+    from oban._executor import Executor
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class FailW2:
+        async def process(self, job):
+            raise ValueError("boom")
+
+    hb = ObanHoneybadger(report_exceptions=False)
+    hb.init()
+    try:
+        job = Job("FailW2", args={}, id=3, attempt=1)
+        with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
+            await Executor(job).execute()
+        assert notify.call_count == 0
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_wrap_result_chains_prior_extension(reset_oban_registry):
+    from oban import worker
+    from oban.job import Job
+    from oban._executor import Executor
+    from oban._extensions import put_ext
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    prior_calls = []
+
+    def prior_ext(j, result):
+        prior_calls.append((j.id, type(result).__name__))
+        return result
+
+    put_ext("executor.wrap_result", prior_ext)
+
+    @worker(queue="default")
+    class FailW3:
+        async def process(self, job):
+            raise ValueError("boom")
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+    try:
+        job = Job("FailW3", args={}, id=4, attempt=1)
+        with patch("honeybadger.contrib.oban.honeybadger.notify"):
+            await Executor(job).execute()
+        assert prior_calls == [(4, "ValueError")]
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_exclude_workers_does_not_filter_errors(reset_oban_registry):
+    """exclude_workers filters Insights events only, not error reporting."""
+    from oban import worker
+    from oban.job import Job
+    from oban._executor import Executor
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class ExcludedW:
+        async def process(self, job):
+            raise ValueError("still reported")
+
+    # Configure to exclude this worker from Insights.
+    hb_module.configure(insights_enabled=True)
+    hb_module.config.insights_config.oban.exclude_workers = ["ExcludedW"]
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+    try:
+        job = Job("ExcludedW", args={}, id=5, attempt=1)
+        with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
+            await Executor(job).execute()
+        # Error path is unaffected by exclude_workers.
+        assert notify.call_count == 1
+    finally:
+        hb.tearDown()
+        from honeybadger.config import Configuration
+
+        hb_module.config = Configuration()
+
+
+@pytest.fixture
+def with_insights():
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.config import Configuration
+
+    hb_module.configure(insights_enabled=True, force_report_data=True)
+    yield hb_module
+    hb_module.config = Configuration()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_stop_emits_insights_event(reset_oban_registry, with_insights):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger.contrib.oban import ObanHoneybadger
+    from honeybadger.utils import filter_dict  # noqa: F401  (ensures import works)
+
+    @worker(queue="default")
+    class StopW:
+        async def process(self, job):
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "StopW",
+            args={"x": 1},
+            id=10,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 5_000_000,  # 5ms in ns
+                    "queue_time": 1_000_000,  # 1ms in ns
+                    "monotonic_time": 0,
+                },
+            )
+        assert event.call_count == 1
+        name, payload = event.call_args[0]
+        assert name == "oban.job_finished"
+        assert payload["job_id"] == 10
+        assert payload["worker"] == "StopW"
+        assert payload["state"] == "completed"
+        assert payload["duration"] == 5.0
+        assert payload["queue_time"] == 1.0
+        # include_args defaults to False — no args/meta in payload.
+        assert "args" not in payload
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_exception_includes_error_fields(
+    reset_oban_registry, with_insights
+):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class ExcW:
+        async def process(self, job):
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "ExcW",
+            args={},
+            id=11,
+            queue="default",
+            attempt=2,
+            max_attempts=5,
+            meta={},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.job.exception",
+                {
+                    "job": job,
+                    "state": "retryable",
+                    "duration": 3_000_000,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                    "error_type": "ValueError",
+                    "error_message": "boom",
+                    "traceback": "fake traceback",
+                },
+            )
+        assert event.call_count == 1
+        _name, payload = event.call_args[0]
+        assert payload["state"] == "retryable"
+        assert payload["error_type"] == "ValueError"
+        assert payload["error_message"] == "boom"
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_exclude_workers_filters_insights_events(
+    reset_oban_registry, with_insights
+):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class NoisyW:
+        async def process(self, job):
+            return None
+
+    hb_module.config.insights_config.oban.exclude_workers = ["NoisyW"]
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "NoisyW",
+            args={},
+            id=12,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 0,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                },
+            )
+        assert event.call_count == 0
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_include_args_filters_sensitive_keys(reset_oban_registry, with_insights):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class ArgsW:
+        async def process(self, job):
+            return None
+
+    hb_module.config.insights_config.oban.include_args = True
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "ArgsW",
+            args={"user_id": 7, "password": "secret"},
+            id=13,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={"token": "xyz", "ok": True},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 0,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                },
+            )
+        _name, payload = event.call_args[0]
+        assert "password" not in payload["args"]
+        assert payload["args"]["user_id"] == 7
+        # meta is not filtered by default params_filters (only "password" etc.),
+        # so "token" passes through unless params_filters configured for it.
+        assert "ok" in payload["meta"]
+        # filter_dict must NOT mutate the live job's dicts.
+        assert job.args == {"user_id": 7, "password": "secret"}
+        assert job.meta == {"token": "xyz", "ok": True}
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_handler_applies_propagated_event_context(
+    reset_oban_registry, with_insights
+):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class CtxTW:
+        async def process(self, job):
+            return None
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "CtxTW",
+            args={},
+            id=14,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={"honeybadger_event_context": {"request_id": "ctx-job"}},
+            tags=[],
+        )
+
+        captured = {}
+
+        def fake_event(name, payload):
+            from honeybadger import honeybadger as hb_module
+
+            captured["ctx_at_event_time"] = hb_module._get_event_context().copy()
+
+        with patch(
+            "honeybadger.contrib.oban.honeybadger.event", side_effect=fake_event
+        ):
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 0,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                },
+            )
+
+        assert captured["ctx_at_event_time"].get("request_id") == "ctx-job"
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_exception_emits_insights_event(
+    reset_oban_registry, with_insights
+):
+    from oban import telemetry
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+            telemetry.execute(
+                "oban.scheduler.evaluate.exception",
+                {
+                    "monotonic_time": 0,
+                    "duration": 2_500_000,  # 2.5ms
+                    "error_type": "RuntimeError",
+                    "error_message": "scheduler tick failed",
+                    "traceback": "fake tb",
+                },
+            )
+        assert event.call_count == 1
+        name, payload = event.call_args[0]
+        assert name == "oban.scheduler_exception"
+        assert payload["loop"] == "scheduler"
+        assert payload["event"] == "oban.scheduler.evaluate.exception"
+        assert payload["error_type"] == "RuntimeError"
+        assert payload["error_message"] == "scheduler tick failed"
+        assert payload["duration"] == 2.5
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_all_loop_exception_events_are_attached(
+    reset_oban_registry, with_insights
+):
+    from oban import telemetry
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    expected = [
+        ("oban.leader.election.exception", "leader"),
+        ("oban.stager.stage.exception", "stager"),
+        ("oban.lifeline.rescue.exception", "lifeline"),
+        ("oban.pruner.prune.exception", "pruner"),
+        ("oban.refresher.refresh.exception", "refresher"),
+        ("oban.refresher.cleanup.exception", "refresher"),
+        ("oban.scheduler.evaluate.exception", "scheduler"),
+        ("oban.producer.fetch.exception", "producer"),
+    ]
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        for evt_name, loop in expected:
+            with patch("honeybadger.contrib.oban.honeybadger.event") as event:
+                telemetry.execute(
+                    evt_name,
+                    {
+                        "monotonic_time": 0,
+                        "duration": 0,
+                        "error_type": "E",
+                        "error_message": "m",
+                        "traceback": "t",
+                    },
+                )
+            assert event.call_count == 1, f"no event for {evt_name}"
+            name, payload = event.call_args[0]
+            assert name == f"oban.{loop}_exception"
+            assert payload["loop"] == loop
+            assert payload["event"] == evt_name
+    finally:
+        hb.tearDown()
+
+
+def test_second_instance_init_raises(reset_oban_registry):
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb1 = ObanHoneybadger()
+    hb1.init()
+    try:
+        hb2 = ObanHoneybadger()
+        with pytest.raises(RuntimeError, match="already initialized"):
+            hb2.init()
+    finally:
+        hb1.tearDown()
+
+
+def test_init_succeeds_after_previous_teardown(reset_oban_registry):
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb1 = ObanHoneybadger()
+    hb1.init()
+    hb1.tearDown()
+
+    hb2 = ObanHoneybadger()
+    hb2.init()  # must not raise
+    hb2.tearDown()
+
+
+def test_same_instance_init_is_idempotent(reset_oban_registry, with_insights):
+    from oban import telemetry
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger()
+    hb.init()
+    hb.init()  # second call should early-return
+    try:
+        handlers = telemetry.core._handlers.get("oban.job.stop", [])
+        ids = [h_id for (h_id, _func) in handlers]
+        # Only one registration of our handler ID.
+        assert ids.count("honeybadger-oban-jobs") == 1
+    finally:
+        hb.tearDown()
+
+
+def test_teardown_on_uninitialized_is_noop(reset_oban_registry):
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger()
+    hb.tearDown()  # must not raise
+
+
+def test_teardown_fully_reverses_init(reset_oban_registry, with_insights):
+    from oban import Oban, worker, telemetry
+    from oban._extensions import _extensions
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class TDW:
+        async def process(self, job):
+            return None
+
+    original_enqueue_many = Oban.enqueue_many
+    original_process = TDW.process
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+
+    # Sanity: wiring is in place.
+    assert Oban.enqueue_many is not original_enqueue_many
+    assert TDW.process is not original_process
+    assert "executor.wrap_result" in _extensions
+    assert telemetry.core._handlers.get("oban.job.stop")
+
+    hb.tearDown()
+
+    # All four wiring sites reversed.
+    assert Oban.enqueue_many is original_enqueue_many
+    assert TDW.process is original_process
+    # executor.wrap_result: restored to identity (or whatever was prior).
+    # We installed nothing prior, so it should equal the identity stored at init time.
+    assert hb._wrap_result_installed is False
+    # Verify the executor.wrap_result extension was actually restored to
+    # identity behavior, not just the flag cleared.
+    from oban._extensions import get_ext
+
+    restored = get_ext("executor.wrap_result", None)
+    sentinel = object()
+    assert restored(None, sentinel) is sentinel
+    # Telemetry handlers detached.
+    handler_ids = [
+        h_id for (h_id, _func) in telemetry.core._handlers.get("oban.job.stop", [])
+    ]
+    assert "honeybadger-oban-jobs" not in handler_ids
+
+
+def test_plugin_generate_payload_filters_sensitive_keys():
+    from honeybadger.contrib.oban import ObanPlugin, _current_job_var
+    from unittest.mock import MagicMock
+
+    job = MagicMock()
+    job.id = 1
+    job.worker = "MyW"
+    job.queue = "default"
+    job.attempt = 1
+    job.max_attempts = 5
+    job.args = {"user_id": 7, "password": "secret", "nested": {"password": "n"}}
+    job.meta = {"token": "xyz", "password": "p"}
+    job.tags = []
+
+    token = _current_job_var.set(job)
+    try:
+        plugin = ObanPlugin()
+        payload = plugin.generate_payload({"request": {}}, {}, {})
+    finally:
+        _current_job_var.reset(token)
+
+    request = payload["request"]
+    # Top-level matching keys are removed (remove_keys=True only applies at top level).
+    assert "password" not in request["params"]["args"]
+    assert "password" not in request["params"]["meta"]
+    assert request["params"]["args"]["user_id"] == 7
+    # Nested matching keys are replaced with "[FILTERED]" (filter_dict's recursion
+    # does not propagate remove_keys).
+    assert request["params"]["args"]["nested"]["password"] == "[FILTERED]"
+    # job state must NOT be mutated by the plugin's filtering.
+    assert job.args["password"] == "secret"
+    assert job.args["nested"]["password"] == "n"
+    assert job.meta["password"] == "p"
+
+
+@pytest.mark.asyncio
+async def test_include_args_deep_copy_does_not_mutate_nested(
+    reset_oban_registry, with_insights
+):
+    from oban import worker, telemetry
+    from oban.job import Job
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class ArgsNestW:
+        async def process(self, job):
+            return None
+
+    hb_module.config.insights_config.oban.include_args = True
+
+    hb = ObanHoneybadger()
+    hb.init()
+    try:
+        job = Job(
+            "ArgsNestW",
+            args={
+                "user_id": 7,
+                "password": "secret",
+                "nested": {"inner_pw": None, "password": "deep"},
+            },
+            id=20,
+            queue="default",
+            attempt=1,
+            max_attempts=5,
+            meta={"token": "xyz", "ok": True},
+            tags=[],
+        )
+        with patch("honeybadger.contrib.oban.honeybadger.event"):
+            telemetry.execute(
+                "oban.job.stop",
+                {
+                    "job": job,
+                    "state": "completed",
+                    "duration": 0,
+                    "queue_time": 0,
+                    "monotonic_time": 0,
+                },
+            )
+        # Nested dict in job.args must NOT be mutated.
+        assert job.args["nested"]["password"] == "deep"
+        assert job.args["password"] == "secret"
+    finally:
+        hb.tearDown()
+
+
+@pytest.mark.asyncio
+async def test_teardown_leaves_later_wrap_result_extension_in_place(
+    reset_oban_registry,
+):
+    from oban._extensions import get_ext, put_ext
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+
+    def later_ext(job, result):
+        return result
+
+    put_ext("executor.wrap_result", later_ext)
+    hb.tearDown()
+
+    # Later integration's extension should still be installed.
+    current = get_ext("executor.wrap_result", None)
+    assert current is later_ext
+
+
+def test_teardown_leaves_later_after_register_extension_in_place(reset_oban_registry):
+    from oban._extensions import get_ext, put_ext
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger()
+    hb.init()
+
+    def later_ext(cls):
+        pass
+
+    put_ext("worker.after_register", later_ext)
+    hb.tearDown()
+
+    current = get_ext("worker.after_register", None)
+    assert current is later_ext
+
+
+@pytest.mark.asyncio
+async def test_wrap_result_inert_after_teardown_via_chained_extension(
+    reset_oban_registry,
+):
+    """After teardown, even if a later integration chains us, our extension must not notify."""
+    from oban import worker
+    from oban.job import Job
+    from oban._executor import Executor
+    from oban._extensions import get_ext, put_ext
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    @worker(queue="default")
+    class InertW:
+        async def process(self, job):
+            raise ValueError("after teardown")
+
+    hb = ObanHoneybadger(report_exceptions=True)
+    hb.init()
+
+    # A later integration captures our handler via the chain pattern.
+    captured_prev = get_ext("executor.wrap_result", lambda _j, r: r)
+
+    def chained(job, result):
+        return captured_prev(job, result)
+
+    put_ext("executor.wrap_result", chained)
+
+    # Now tear down. The chained later-extension still holds a reference to our handler.
+    hb.tearDown()
+
+    # Run a failing job. Our extension's closure will still be called via the chain,
+    # but it must NOT call honeybadger.notify.
+    job = Job("InertW", args={}, id=1, attempt=1)
+    with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
+        await Executor(job).execute()
+    assert notify.call_count == 0
+
+
+def test_after_register_inert_after_teardown_via_chained_extension(reset_oban_registry):
+    """After teardown, late-registered workers must not get wrapped by our chain."""
+    from oban import worker
+    from oban._extensions import get_ext, put_ext
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    hb = ObanHoneybadger()
+    hb.init()
+
+    captured_prev = get_ext("worker.after_register", lambda _cls: None)
+
+    def chained(cls):
+        captured_prev(cls)
+
+    put_ext("worker.after_register", chained)
+
+    hb.tearDown()
+
+    @worker(queue="default")
+    class LateW:
+        async def process(self, job):
+            return None
+
+    # If our chain had wrapped LateW, _honeybadger_process_wrapped would be set.
+    assert not getattr(LateW, "_honeybadger_process_wrapped", False)

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -876,7 +876,8 @@ async def test_all_loop_exception_events_are_attached(
         ("oban.refresher.refresh.exception", "refresher"),
         ("oban.refresher.cleanup.exception", "refresher"),
         ("oban.scheduler.evaluate.exception", "scheduler"),
-        ("oban.producer.fetch.exception", "producer"),
+        ("oban.producer.get.exception", "producer"),
+        ("oban.producer.ack.exception", "producer"),
     ]
 
     hb = ObanHoneybadger()
@@ -901,6 +902,35 @@ async def test_all_loop_exception_events_are_attached(
             assert payload["event"] == evt_name
     finally:
         hb.tearDown()
+
+
+def test_loop_exception_events_exist_in_oban():
+    """Every subscribed loop event must match a telemetry.span prefix that the
+    installed oban version actually emits — guards against subscribing to
+    renamed or nonexistent events (which fail silently)."""
+    import inspect
+    import os
+    import re
+
+    import oban as oban_pkg
+    from honeybadger.contrib.oban import _LOOP_EXCEPTION_EVENTS
+
+    src_dir = os.path.dirname(inspect.getfile(oban_pkg))
+    span_prefixes = set()
+    for fname in os.listdir(src_dir):
+        if fname.endswith(".py"):
+            with open(os.path.join(src_dir, fname)) as f:
+                span_prefixes.update(
+                    re.findall(r'telemetry\.span\(\s*"([^"]+)"', f.read())
+                )
+
+    assert span_prefixes, "found no telemetry.span calls in oban source"
+    for evt in _LOOP_EXCEPTION_EVENTS:
+        prefix = evt.rsplit(".", 1)[0]  # strip trailing ".exception"
+        assert prefix in span_prefixes, (
+            f"{evt} does not match any telemetry.span prefix in oban "
+            f"{getattr(oban_pkg, '__version__', '?')}: {sorted(span_prefixes)}"
+        )
 
 
 def test_second_instance_init_raises(reset_oban_registry):

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -99,18 +99,26 @@ def test_event_context_from_meta_ignores_non_dict_meta():
 
 @pytest.fixture
 def reset_oban_registry():
-    """Clear the worker registry and our active-instance state before each test."""
+    """Clear the worker registry, our active-instance state, and any leaked
+    Honeybadger context before AND after each test. Tests assert on the
+    "no context set" state, which requires defending against pollution from
+    unrelated tests in the same process run.
+    """
     from oban.worker import _registry
     from oban._extensions import _extensions
+    from honeybadger import honeybadger as hb_module
     import honeybadger.contrib.oban as hb_oban
 
-    _registry.clear()
-    _extensions.clear()
-    hb_oban._active_instance = None
+    def _reset():
+        _registry.clear()
+        _extensions.clear()
+        hb_oban._active_instance = None
+        hb_module.reset_context()
+        hb_module.reset_event_context()
+
+    _reset()
     yield
-    _registry.clear()
-    _extensions.clear()
-    hb_oban._active_instance = None
+    _reset()
 
 
 def test_construction_without_init_does_not_register_plugin(reset_oban_registry):
@@ -362,6 +370,7 @@ async def test_wrap_result_reports_exception_for_worker_class(reset_oban_registr
     from oban import worker
     from oban.job import Job
     from oban._executor import Executor
+    from oban.worker import worker_name
     from honeybadger.contrib.oban import ObanHoneybadger
 
     @worker(queue="default")
@@ -372,7 +381,10 @@ async def test_wrap_result_reports_exception_for_worker_class(reset_oban_registr
     hb = ObanHoneybadger(report_exceptions=True)
     hb.init()
     try:
-        job = Job("FailW", args={}, id=1, attempt=1)
+        # Use the fully-qualified registry name so Executor.resolve_worker
+        # can actually import this class instead of failing with
+        # ValueError("Empty module name") on a bare label.
+        job = Job(worker_name(FailW), args={}, id=1, attempt=1)
         with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
             await Executor(job).execute()
         assert notify.call_count == 1
@@ -414,6 +426,7 @@ async def test_no_notify_when_report_exceptions_false(reset_oban_registry):
     from oban import worker
     from oban.job import Job
     from oban._executor import Executor
+    from oban.worker import worker_name
     from honeybadger.contrib.oban import ObanHoneybadger
 
     @worker(queue="default")
@@ -424,7 +437,7 @@ async def test_no_notify_when_report_exceptions_false(reset_oban_registry):
     hb = ObanHoneybadger(report_exceptions=False)
     hb.init()
     try:
-        job = Job("FailW2", args={}, id=3, attempt=1)
+        job = Job(worker_name(FailW2), args={}, id=3, attempt=1)
         with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
             await Executor(job).execute()
         assert notify.call_count == 0
@@ -438,6 +451,7 @@ async def test_wrap_result_chains_prior_extension(reset_oban_registry):
     from oban.job import Job
     from oban._executor import Executor
     from oban._extensions import put_ext
+    from oban.worker import worker_name
     from honeybadger.contrib.oban import ObanHoneybadger
 
     prior_calls = []
@@ -456,7 +470,7 @@ async def test_wrap_result_chains_prior_extension(reset_oban_registry):
     hb = ObanHoneybadger(report_exceptions=True)
     hb.init()
     try:
-        job = Job("FailW3", args={}, id=4, attempt=1)
+        job = Job(worker_name(FailW3), args={}, id=4, attempt=1)
         with patch("honeybadger.contrib.oban.honeybadger.notify"):
             await Executor(job).execute()
         assert prior_calls == [(4, "ValueError")]
@@ -470,6 +484,7 @@ async def test_exclude_workers_does_not_filter_errors(reset_oban_registry):
     from oban import worker
     from oban.job import Job
     from oban._executor import Executor
+    from oban.worker import worker_name
     from honeybadger import honeybadger as hb_module
     from honeybadger.contrib.oban import ObanHoneybadger
 
@@ -480,12 +495,12 @@ async def test_exclude_workers_does_not_filter_errors(reset_oban_registry):
 
     # Configure to exclude this worker from Insights.
     hb_module.configure(insights_enabled=True)
-    hb_module.config.insights_config.oban.exclude_workers = ["ExcludedW"]
+    hb_module.config.insights_config.oban.exclude_workers = [worker_name(ExcludedW)]
 
     hb = ObanHoneybadger(report_exceptions=True)
     hb.init()
     try:
-        job = Job("ExcludedW", args={}, id=5, attempt=1)
+        job = Job(worker_name(ExcludedW), args={}, id=5, attempt=1)
         with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
             await Executor(job).execute()
         # Error path is unaffected by exclude_workers.
@@ -1078,7 +1093,9 @@ async def test_wrap_result_inert_after_teardown_via_chained_extension(
 
     # Run a failing job. Our extension's closure will still be called via the chain,
     # but it must NOT call honeybadger.notify.
-    job = Job("InertW", args={}, id=1, attempt=1)
+    from oban.worker import worker_name
+
+    job = Job(worker_name(InertW), args={}, id=1, attempt=1)
     with patch("honeybadger.contrib.oban.honeybadger.notify") as notify:
         await Executor(job).execute()
     assert notify.call_count == 0

--- a/honeybadger/tests/contrib/test_oban.py
+++ b/honeybadger/tests/contrib/test_oban.py
@@ -1109,3 +1109,58 @@ def test_after_register_inert_after_teardown_via_chained_extension(reset_oban_re
 
     # If our chain had wrapped LateW, _honeybadger_process_wrapped would be set.
     assert not getattr(LateW, "_honeybadger_process_wrapped", False)
+
+
+def test_is_worker_excluded_handles_none_patterns():
+    """exclude_workers=None (dataclass field is not type-validated) must not crash."""
+    from honeybadger.contrib.oban import ObanHoneybadger
+
+    assert ObanHoneybadger._is_worker_excluded("any.Worker", None) is False
+    assert ObanHoneybadger._is_worker_excluded("any.Worker", []) is False
+
+
+def test_init_failure_releases_active_instance_and_unwinds_partial(reset_oban_registry):
+    """A failure mid-init() must release the single-instance lock and unwind partials."""
+    from oban import Oban, worker
+    from honeybadger import honeybadger as hb_module
+    from honeybadger.config import Configuration
+    from honeybadger.contrib.oban import ObanHoneybadger
+    import honeybadger.contrib.oban as hb_oban
+    import oban.telemetry as oban_telemetry
+
+    @worker(queue="default")
+    class PartialW:
+        async def process(self, job):
+            return None
+
+    original_process = PartialW.process
+    original_enqueue_many = Oban.enqueue_many
+    original_attach = oban_telemetry.attach
+
+    hb_module.configure(insights_enabled=True)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom from attach")
+
+    oban_telemetry.attach = boom
+    hb = ObanHoneybadger(report_exceptions=True)
+    try:
+        with pytest.raises(RuntimeError, match="boom from attach"):
+            hb.init()
+
+        # Single-instance lock released, init flag still False.
+        assert hb_oban._active_instance is None
+        assert hb._initialized is False
+
+        # Partial wiring reverted: worker process restored, enqueue_many restored.
+        assert PartialW.process is original_process
+        assert Oban.enqueue_many is original_enqueue_many
+
+        # A fresh init on a new instance must succeed after the prior failure.
+        oban_telemetry.attach = original_attach
+        hb2 = ObanHoneybadger()
+        hb2.init()
+        hb2.tearDown()
+    finally:
+        oban_telemetry.attach = original_attach
+        hb_module.config = Configuration()

--- a/honeybadger/tests/test_config.py
+++ b/honeybadger/tests/test_config.py
@@ -181,3 +181,23 @@ def test_configure_merges_insights_config():
     assert c.insights_config.celery.disabled is True
 
     assert c.insights_config.db.include_params is True
+
+
+def test_insights_config_has_oban_field():
+    from honeybadger.config import InsightsConfig, ObanConfig
+
+    cfg = InsightsConfig()
+    assert isinstance(cfg.oban, ObanConfig)
+    assert cfg.oban.disabled is False
+    assert cfg.oban.exclude_workers == []
+    assert cfg.oban.include_args is False
+
+
+def test_oban_config_accepts_exclude_workers_patterns():
+    import re
+    from honeybadger.config import ObanConfig
+
+    cfg = ObanConfig(
+        exclude_workers=["myapp.LowPriorityWorker", re.compile(r"^cron\.")]
+    )
+    assert len(cfg.exclude_workers) == 2

--- a/honeybadger/utils.py
+++ b/honeybadger/utils.py
@@ -90,6 +90,18 @@ def get_duration(start_time):
     return round((time.monotonic() - start_time) * 1000, 4)
 
 
+def matches_any_pattern(name, patterns):
+    """Whether name matches any of patterns: compiled regexes are matched via
+    .search(), anything else by equality. Used for exclude lists that accept
+    both exact strings and re.Pattern objects."""
+    if not patterns:
+        return False
+    return any(
+        pattern.search(name) if hasattr(pattern, "search") else pattern == name
+        for pattern in patterns
+    )
+
+
 def sanitize_request_id(request_id):
     """Sanitize a Request ID by keeping only alphanumeric characters and hyphens."""
     if not request_id:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+
+# oban is only installable on Python >= 3.12 (its requires-python). The
+# honeybadger.contrib.oban module imports oban lazily so the module file
+# itself imports cleanly on older Pythons. On CI rows where Python < 3.12
+# (and therefore oban is not installed), suppress the resulting
+# import-not-found errors for oban.* only — other missing imports still fail.
+[mypy-oban.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary

- Adds `honeybadger/contrib/oban.py` and an `ObanConfig` dataclass to instrument [Oban for Python](https://github.com/oban-bg/oban-py), reporting unhandled worker exceptions to Honeybadger and emitting per-job plus maintenance-loop telemetry to Honeybadger Insights.
- Wires into oban-py via an `executor.wrap_result` extension (for error reporting with the live exception), an `Oban.enqueue_many` monkey-patch (for Honeybadger event-context propagation across the enqueue→execute boundary), a per-worker `process` wrap chained through `worker.after_register` so late-registered workers are covered, and telemetry handlers for `oban.job.{stop,exception}` and the eight maintenance-loop `.exception` events.
- Includes deep-copy filtering through `params_filters` before job args/meta are exposed in error notices, a single-instance guard, and an inert-after-`tearDown()` pattern so chained extensions stop auto-reporting after teardown.
- Requires Python 3.12+; `dev-requirements.txt` pins `oban==0.6.2` with a `python_version >= "3.12"` environment marker so older matrix rows skip cleanly. 40 tests gated by `skipif(sys.version_info < (3, 12))` cover the public API, chain/inert behavior, exclude/include config, context-propagation round-trip, and full teardown reversibility.

## Test plan

- [ ] CI matrix rows on Python 3.12 / 3.13 / 3.14 install `oban==0.6.2` and run all 40 contrib tests.
- [ ] CI rows on Python 3.9 / 3.10 / 3.11 skip the test file via \`pytestmark\` and do not attempt to install oban.
- [ ] Manual: in a real app with \`insights_enabled=True\`, verify that an enqueue from inside a request causes \`oban.job_finished\` Insights events to carry the request's event context, and that a raising worker produces a Honeybadger error notice with worker name, args, queue, attempt, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)