### PR TITLE
fix(config): typecast float env vars; keep events worker alive on bad config

### DIFF
--- a/honeybadger/config.py
+++ b/honeybadger/config.py
@@ -140,6 +140,8 @@ class Configuration(BaseConfig):
                         val = env_val.split(",")
                     elif typ == int:
                         val = int(env_val)
+                    elif typ == float:
+                        val = float(env_val)
                     elif typ == bool:
                         val = env_val.lower() in ("true", "1", "yes")
                     else:

--- a/honeybadger/events_worker.py
+++ b/honeybadger/events_worker.py
@@ -35,7 +35,7 @@ class EventsWorker:
         self._batches: Deque[Tuple[List[Event], int]] = deque()
 
         self._throttled = False
-        self._stop = False
+        self._stop_event = threading.Event()
         self._dropped = 0
         self._last_drop_log = time.monotonic()
         self._start_time = time.monotonic()
@@ -54,7 +54,7 @@ class EventsWorker:
             self.shutdown()
 
         # Reset state
-        self._stop = False
+        self._stop_event.clear()
 
         self._thread = threading.Thread(
             target=self._run,
@@ -82,7 +82,7 @@ class EventsWorker:
 
     def shutdown(self) -> None:
         self.log.debug("Shutting down events worker")
-        self._stop = True
+        self._stop_event.set()
         self._batch_ready_event.set()  # Wake up the worker thread
 
         if self._thread.is_alive():
@@ -118,7 +118,11 @@ class EventsWorker:
 
                 # Check if we should exit (need consistent view of state)
                 with self._lock:
-                    if self._stop and not self._queue and not self._batches:
+                    if (
+                        self._stop_event.is_set()
+                        and not self._queue
+                        and not self._batches
+                    ):
                         break
 
                 # Perform send/retry logic
@@ -128,9 +132,12 @@ class EventsWorker:
                 # not kill the worker thread — that would silently drop every
                 # future event. Log, then keep the loop alive.
                 self.log.exception("Unexpected error in events worker loop")
-                if self._stop:
+                if self._stop_event.is_set():
                     break
-                time.sleep(1.0)  # avoid a hot loop if the error is persistent
+                # Back off to avoid a hot loop on persistent errors, but wait
+                # on the stop event so shutdown() wakes us immediately instead
+                # of returning while we're still asleep.
+                self._stop_event.wait(1.0)
 
     def _flush(self) -> None:
         """

--- a/honeybadger/events_worker.py
+++ b/honeybadger/events_worker.py
@@ -116,7 +116,12 @@ class EventsWorker:
                 self._batch_ready_event.wait(timeout=self._compute_timeout())
                 self._batch_ready_event.clear()
 
-                # Check if we should exit (need consistent view of state)
+                # Perform send/retry logic
+                self._flush()
+
+                # Check if we should exit — after flushing, so a drained
+                # shutdown breaks now instead of blocking in one more wait()
+                # (need consistent view of state)
                 with self._lock:
                     if (
                         self._stop_event.is_set()
@@ -124,9 +129,6 @@ class EventsWorker:
                         and not self._batches
                     ):
                         break
-
-                # Perform send/retry logic
-                self._flush()
             except Exception:
                 # An unexpected error (e.g. a misconfigured timeout value) must
                 # not kill the worker thread — that would silently drop every

--- a/honeybadger/events_worker.py
+++ b/honeybadger/events_worker.py
@@ -111,17 +111,26 @@ class EventsWorker:
         Main loop: wait until stop or enough events to batch, then flush.
         """
         while True:
-            # Wait for batch ready signal or timeout
-            self._batch_ready_event.wait(timeout=self._compute_timeout())
-            self._batch_ready_event.clear()
+            try:
+                # Wait for batch ready signal or timeout
+                self._batch_ready_event.wait(timeout=self._compute_timeout())
+                self._batch_ready_event.clear()
 
-            # Check if we should exit (need consistent view of state)
-            with self._lock:
-                if self._stop and not self._queue and not self._batches:
+                # Check if we should exit (need consistent view of state)
+                with self._lock:
+                    if self._stop and not self._queue and not self._batches:
+                        break
+
+                # Perform send/retry logic
+                self._flush()
+            except Exception:
+                # An unexpected error (e.g. a misconfigured timeout value) must
+                # not kill the worker thread — that would silently drop every
+                # future event. Log, then keep the loop alive.
+                self.log.exception("Unexpected error in events worker loop")
+                if self._stop:
                     break
-
-            # Perform send/retry logic
-            self._flush()
+                time.sleep(1.0)  # avoid a hot loop if the error is persistent
 
     def _flush(self) -> None:
         """

--- a/honeybadger/events_worker.py
+++ b/honeybadger/events_worker.py
@@ -87,14 +87,17 @@ class EventsWorker:
 
         if self._thread.is_alive():
             try:
+                # Coerce to float so the result is always numeric — with two
+                # string values, max(str, str) * 2 would "succeed" and hand
+                # join() a string.
                 timeout = (
                     max(
-                        self.config.events_timeout,
-                        self.config.events_throttle_wait,
+                        float(self.config.events_timeout),
+                        float(self.config.events_throttle_wait),
                     )
                     * 2
                 )
-            except TypeError:
+            except (TypeError, ValueError):
                 # Config values may be invalid (e.g. untypecast env vars) —
                 # the worker exits promptly on such errors once stopped, so a
                 # modest fallback join timeout is enough.

--- a/honeybadger/events_worker.py
+++ b/honeybadger/events_worker.py
@@ -86,13 +86,19 @@ class EventsWorker:
         self._batch_ready_event.set()  # Wake up the worker thread
 
         if self._thread.is_alive():
-            timeout = (
-                max(
-                    self.config.events_timeout,
-                    self.config.events_throttle_wait,
+            try:
+                timeout = (
+                    max(
+                        self.config.events_timeout,
+                        self.config.events_throttle_wait,
+                    )
+                    * 2
                 )
-                * 2
-            )
+            except TypeError:
+                # Config values may be invalid (e.g. untypecast env vars) —
+                # the worker exits promptly on such errors once stopped, so a
+                # modest fallback join timeout is enough.
+                timeout = 10.0
             self._thread.join(timeout)
         self.log.debug("Events worker stopped")
 

--- a/honeybadger/tests/test_config.py
+++ b/honeybadger/tests/test_config.py
@@ -37,6 +37,27 @@ def test_config_bool_types_are_accurate():
     assert c.force_report_data == True
 
 
+def test_config_float_types_are_accurate():
+    os.environ["HONEYBADGER_EVENTS_TIMEOUT"] = "2.5"
+    os.environ["HONEYBADGER_EVENTS_THROTTLE_WAIT"] = "30"
+    try:
+        c = Configuration()
+    finally:
+        del os.environ["HONEYBADGER_EVENTS_TIMEOUT"]
+        del os.environ["HONEYBADGER_EVENTS_THROTTLE_WAIT"]
+    assert c.events_timeout == 2.5
+    assert c.events_throttle_wait == 30.0
+
+
+def test_config_invalid_float_env_var_keeps_default():
+    os.environ["HONEYBADGER_EVENTS_TIMEOUT"] = "not-a-number"
+    try:
+        c = Configuration()
+    finally:
+        del os.environ["HONEYBADGER_EVENTS_TIMEOUT"]
+    assert c.events_timeout == 5.0
+
+
 def test_can_only_set_valid_options(caplog):
     with caplog.at_level(logging.WARNING):
         try:

--- a/honeybadger/tests/test_events_worker.py
+++ b/honeybadger/tests/test_events_worker.py
@@ -358,6 +358,18 @@ def test_shutdown_interrupts_error_backoff(base_config):
     assert elapsed < 0.5, f"shutdown blocked {elapsed:.2f}s on error backoff"
 
 
+def test_shutdown_with_still_invalid_timeout_config(base_config):
+    """shutdown() must not crash computing its join timeout when the config
+    is still invalid at shutdown time."""
+    cfg = SimpleNamespace(**vars(base_config))
+    cfg.events_timeout = "not-a-number"
+    conn = DummyConnection()
+    w = EventsWorker(connection=conn, config=cfg)
+    time.sleep(0.05)  # let the worker enter its error backoff
+    w.shutdown()  # must not raise
+    assert not w._thread.is_alive()
+
+
 def test_worker_survives_bad_timeout_config(base_config):
     """A misconfigured (non-numeric) timeout must not kill the worker thread:
     events pushed after the error must still be delivered once the config is

--- a/honeybadger/tests/test_events_worker.py
+++ b/honeybadger/tests/test_events_worker.py
@@ -319,6 +319,26 @@ def test_send_remaining_on_shutdown(base_config):
     assert conn.batches[-1] == [{"id": 1}, {"id": 2}]
 
 
+def test_shutdown_returns_promptly_after_drain(base_config):
+    """Once shutdown() drains the queue, the worker must exit immediately —
+    not block in another wait(events_timeout) before noticing it's done."""
+    cfg = SimpleNamespace(**vars(base_config))
+    cfg.events_batch_size = 100
+    cfg.events_timeout = 1.0
+    conn = DummyConnection()
+    w = EventsWorker(connection=conn, config=cfg)
+    for e in ({"id": 1}, {"id": 2}):
+        w.push(e)
+
+    start = time.monotonic()
+    w.shutdown()
+    elapsed = time.monotonic() - start
+
+    assert conn.batches[-1] == [{"id": 1}, {"id": 2}]
+    assert not w._thread.is_alive()
+    assert elapsed < 0.5, f"shutdown took {elapsed:.2f}s after events were drained"
+
+
 def test_shutdown_interrupts_error_backoff(base_config):
     """shutdown() must wake the worker out of its error backoff and only
     report stopped once the thread has actually exited — not return while

--- a/honeybadger/tests/test_events_worker.py
+++ b/honeybadger/tests/test_events_worker.py
@@ -319,6 +319,25 @@ def test_send_remaining_on_shutdown(base_config):
     assert conn.batches[-1] == [{"id": 1}, {"id": 2}]
 
 
+def test_shutdown_interrupts_error_backoff(base_config):
+    """shutdown() must wake the worker out of its error backoff and only
+    report stopped once the thread has actually exited — not return while
+    the worker is still sleeping."""
+    cfg = SimpleNamespace(**vars(base_config))
+    cfg.events_timeout = "not-a-number"  # worker loop errors -> backoff path
+    conn = DummyConnection()
+    w = EventsWorker(connection=conn, config=cfg)
+    time.sleep(0.05)  # let the worker enter its error backoff
+    cfg.events_timeout = 0.1  # sane join timeout for shutdown
+
+    start = time.monotonic()
+    w.shutdown()
+    elapsed = time.monotonic() - start
+
+    assert not w._thread.is_alive(), "shutdown returned with worker still alive"
+    assert elapsed < 0.5, f"shutdown blocked {elapsed:.2f}s on error backoff"
+
+
 def test_worker_survives_bad_timeout_config(base_config):
     """A misconfigured (non-numeric) timeout must not kill the worker thread:
     events pushed after the error must still be delivered once the config is

--- a/honeybadger/tests/test_events_worker.py
+++ b/honeybadger/tests/test_events_worker.py
@@ -370,6 +370,19 @@ def test_shutdown_with_still_invalid_timeout_config(base_config):
     assert not w._thread.is_alive()
 
 
+def test_shutdown_with_both_timing_configs_invalid(base_config):
+    """With both timing values non-numeric, max(str, str) * 2 is a string —
+    the join timeout must be coerced to a number before calling join()."""
+    cfg = SimpleNamespace(**vars(base_config))
+    cfg.events_timeout = "not-a-number"
+    cfg.events_throttle_wait = "also-bad"
+    conn = DummyConnection()
+    w = EventsWorker(connection=conn, config=cfg)
+    time.sleep(0.05)  # let the worker enter its error backoff
+    w.shutdown()  # must not raise
+    assert not w._thread.is_alive()
+
+
 def test_worker_survives_bad_timeout_config(base_config):
     """A misconfigured (non-numeric) timeout must not kill the worker thread:
     events pushed after the error must still be delivered once the config is

--- a/honeybadger/tests/test_events_worker.py
+++ b/honeybadger/tests/test_events_worker.py
@@ -317,3 +317,25 @@ def test_send_remaining_on_shutdown(base_config):
         w.push(e)
     w.shutdown()
     assert conn.batches[-1] == [{"id": 1}, {"id": 2}]
+
+
+def test_worker_survives_bad_timeout_config(base_config):
+    """A misconfigured (non-numeric) timeout must not kill the worker thread:
+    events pushed after the error must still be delivered once the config is
+    corrected."""
+    cfg = SimpleNamespace(**vars(base_config))
+    cfg.events_timeout = "not-a-number"  # e.g. an untypecast env var
+    conn = DummyConnection()
+    w = EventsWorker(connection=conn, config=cfg)
+    try:
+        time.sleep(0.1)  # give the loop a chance to hit the bad timeout
+        assert w._thread.is_alive(), "worker thread died on bad timeout config"
+
+        cfg.events_timeout = 0.1  # operator fixes the config
+        for e in ({"id": 1}, {"id": 2}, {"id": 3}):  # batch size reached
+            w.push(e)
+        assert wait_for(lambda: len(conn.batches) >= 1, timeout=3.0)
+        assert conn.batches[0] == [{"id": 1}, {"id": 2}, {"id": 3}]
+    finally:
+        cfg.events_timeout = 0.1
+        w.shutdown()


### PR DESCRIPTION
`HONEYBADGER_EVENTS_TIMEOUT` / `HONEYBADGER_EVENTS_THROTTLE_WAIT` were stored as strings because `set_12factor_config` had no `float` branch, and `Event.wait(timeout="...")` then raised `TypeError` inside the events worker loop, silently killing the thread and dropping all future Insights events. This adds float typecasting for env vars (invalid values keep the default) and guards the worker loop so unexpected errors are logged instead of fatal, with a 1s backoff to avoid a hot loop. The backoff waits on a stop event (replacing the `_stop` bool) so `shutdown()` wakes the worker immediately rather than returning while the thread is still asleep. Includes tests for float parsing, invalid-value fallback, worker survival under a bad timeout config, and prompt shutdown from the error backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)